### PR TITLE
Fix SendDeathMessage return value for unconnected killee

### DIFF
--- a/Server/Components/Pawn/Scripting/Player/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Player/Natives.cpp
@@ -98,6 +98,10 @@ SCRIPT_API(SendDeathMessage, bool(IPlayer* killer, IPlayer* killee, int weapon))
 	{
 		PawnManager::Get()->players->sendDeathMessageToAll(killer, *killee, weapon);
 	}
+	else
+	{
+		PawnManager::Get()->core->logLn(LogLevel::Warning, "SendDeathMessage: Invalid playerid specified.");
+	}
 
 	return true;
 }


### PR DESCRIPTION
SendDeathMessage is supposed to always return 1, even if killee ID is invalid. This PR addresses that.