### PR TITLE
throw warning instead of failing code execution for clf/crf

### DIFF
--- a/Server/Components/Pawn/utils.hpp
+++ b/Server/Components/Pawn/utils.hpp
@@ -247,8 +247,7 @@ namespace utils {
 		amx_StrParamChar(amx, params[2], fmat);
 		if (num != (int)(2 + strlen(fmat)))
 		{
-			PawnManager::Get()->core->logLn(LogLevel::Error, "Parameter count does not match specifier in `Script_Call`. callback: %s - fmat: %s - count: %d)", name, fmat, num - 2);
-			return 0;
+			PawnManager::Get()->core->logLn(LogLevel::Warning, "Parameter count does not match specifier in `Script_Call`. callback: %s - fmat: %s - count: %d)", name, fmat, num - 2);
 		}
 		cell *
 			data,
@@ -325,8 +324,7 @@ namespace utils {
 		amx_StrParamChar(amx, params[3], fmat);
 		if (num != (int)(2 + strlen(fmat)))
 		{
-			PawnManager::Get()->core->logLn(LogLevel::Error, "Parameter count does not match specifier in `Script_CallOne`. callback: %s - fmat: %s - count: %d)", name, fmat, num - 2);
-			return 0;
+			PawnManager::Get()->core->logLn(LogLevel::Warning, "Parameter count does not match specifier in `Script_CallOne`. callback: %s - fmat: %s - count: %d)", name, fmat, num - 2);
 		}
 		cell *
 			data,
@@ -393,8 +391,7 @@ namespace utils {
 		amx_StrParamChar(amx, params[2], fmat);
 		if (num != (int)(2 + strlen(fmat)))
 		{
-			PawnManager::Get()->core->logLn(LogLevel::Error, "Parameter count does not match specifier in `Script_CallAll`. callback: %s - fmat: %s - count: %d)", name, fmat, num - 2);
-			return 0;
+			PawnManager::Get()->core->logLn(LogLevel::Warning, "Parameter count does not match specifier in `Script_CallAll`. callback: %s - fmat: %s - count: %d)", name, fmat, num - 2);
 		}
 		struct parameter_s
 		{


### PR DESCRIPTION
instead of failing and breaking code execution when arg count doesn't match passed specifiers, print a warning to let user know there's something wrong and still execute the rest, if there are more specifiers, then we pass empty values (or garbage for strings/arrays) and if there are less it automatically ignores extra passed args