### PR TITLE
Fix checkpoint issues and inconsistencies

### DIFF
--- a/SDK/Server/Components/Checkpoints/checkpoints.hpp
+++ b/SDK/Server/Components/Checkpoints/checkpoints.hpp
@@ -30,19 +30,23 @@ struct ICheckpointDataBase {
 	virtual bool isEnabled() const = 0;
 };
 
-static const UUID PlayerCheckpointData_UUID = UUID(0xbc07576aa3591a66);
-struct IPlayerCheckpointData : public ICheckpointDataBase, public IPlayerData {
-	PROVIDE_UUID(PlayerCheckpointData_UUID);
+struct IPlayerStandardCheckpointData : public ICheckpointDataBase {
+
 };
 
-static const UUID PlayerRaceCheckpointData_UUID = UUID(0x3beffcbfd55c8b7c);
-struct IPlayerRaceCheckpointData :public ICheckpointDataBase, public IPlayerData {
-	PROVIDE_UUID(PlayerRaceCheckpointData_UUID);
-
+struct IPlayerRaceCheckpointData : public ICheckpointDataBase {
 	virtual RaceCheckpointType getType() const = 0;
 	virtual void setType(RaceCheckpointType type) = 0;
 	virtual Vector3 getNextPosition() const = 0;
 	virtual void setNextPosition(const Vector3& nextPosition) = 0;
+};
+
+static const UUID PlayerCheckpointData_UUID = UUID(0xbc07576aa3591a66);
+struct IPlayerCheckpointData : public IPlayerData {
+	PROVIDE_UUID(PlayerCheckpointData_UUID);
+
+	virtual IPlayerRaceCheckpointData& getRaceCheckpoint() = 0;
+	virtual IPlayerStandardCheckpointData& getStandardCheckpoint() = 0;
 };
 
 struct PlayerCheckpointEventHandler {

--- a/Server/Components/Pawn/Scripting/Checkpoint/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Checkpoint/Natives.cpp
@@ -5,11 +5,12 @@
 
 SCRIPT_API(SetPlayerCheckpoint, bool(IPlayer& player, Vector3 position, float size))
 {
-	IPlayerCheckpointData* cp = player.queryData<IPlayerCheckpointData>();
-	if (cp) {
-		cp->setPosition(position);
-		cp->setRadius(size / 2.0f);
-		cp->enable();
+	IPlayerCheckpointData* playerCheckpointData = player.queryData<IPlayerCheckpointData>();
+	if (playerCheckpointData) {
+		IPlayerStandardCheckpointData& cp = playerCheckpointData->getStandardCheckpoint();
+		cp.setPosition(position);
+		cp.setRadius(size / 2.0f); // samp native receives diameter so we turn this into radius
+		cp.enable();
 		return true;
 	}
 	return false;
@@ -17,9 +18,10 @@ SCRIPT_API(SetPlayerCheckpoint, bool(IPlayer& player, Vector3 position, float si
 
 SCRIPT_API(DisablePlayerCheckpoint, bool(IPlayer& player))
 {
-	IPlayerCheckpointData* cp = player.queryData<IPlayerCheckpointData>();
-	if (cp) {
-		cp->disable();
+	IPlayerCheckpointData* playerCheckpointData = player.queryData<IPlayerCheckpointData>();
+	if (playerCheckpointData) {
+		IPlayerStandardCheckpointData& cp = playerCheckpointData->getStandardCheckpoint();
+		cp.disable();
 		return true;
 	}
 	return false;
@@ -27,32 +29,39 @@ SCRIPT_API(DisablePlayerCheckpoint, bool(IPlayer& player))
 
 SCRIPT_API(IsPlayerInCheckpoint, bool(IPlayer& player))
 {
-	IPlayerCheckpointData* cp = player.queryData<IPlayerCheckpointData>();
-	if (cp->isEnabled()) {
-		return cp->isPlayerInside();
+	IPlayerCheckpointData* playerCheckpointData = player.queryData<IPlayerCheckpointData>();
+	if (playerCheckpointData) {
+		IPlayerStandardCheckpointData& cp = playerCheckpointData->getStandardCheckpoint();
+		if (cp.isEnabled()) {
+			return cp.isPlayerInside();
+		}
 	}
 	return false;
 }
 
 SCRIPT_API(SetPlayerRaceCheckpoint, bool(IPlayer& player, int type, Vector3 position, Vector3 nextPosition, float size))
 {
-	IPlayerRaceCheckpointData* cp = player.queryData<IPlayerRaceCheckpointData>();
-	if (cp && type >= 0 && type <= 8) {
-		cp->setType(RaceCheckpointType(type));
-		cp->setPosition(position);
-		cp->setNextPosition(nextPosition);
-		cp->setRadius(size / 2.0f);
-		cp->enable();
-		return true;
+	IPlayerCheckpointData* playerCheckpointData = player.queryData<IPlayerCheckpointData>();
+	if (playerCheckpointData) {
+		IPlayerRaceCheckpointData& cp = playerCheckpointData->getRaceCheckpoint();
+		if (type >= 0 && type <= 8) {
+			cp.setType(RaceCheckpointType(type));
+			cp.setPosition(position);
+			cp.setNextPosition(nextPosition);
+			cp.setRadius(size); // samp native receives radius unlike standard checkpoints
+			cp.enable();
+			return true;
+		}
 	}
 	return false;
 }
 
 SCRIPT_API(DisablePlayerRaceCheckpoint, bool(IPlayer& player))
 {
-	IPlayerRaceCheckpointData* cp = player.queryData<IPlayerRaceCheckpointData>();
-	if (cp) {
-		cp->disable();
+	IPlayerCheckpointData* playerCheckpointData = player.queryData<IPlayerCheckpointData>();
+	if (playerCheckpointData) {
+		IPlayerRaceCheckpointData& cp = playerCheckpointData->getRaceCheckpoint();
+		cp.disable();
 		return true;
 	}
 	return false;
@@ -60,9 +69,12 @@ SCRIPT_API(DisablePlayerRaceCheckpoint, bool(IPlayer& player))
 
 SCRIPT_API(IsPlayerInRaceCheckpoint, bool(IPlayer& player))
 {
-	IPlayerRaceCheckpointData* cp = player.queryData<IPlayerRaceCheckpointData>();
-	if (cp && cp->getType() != RaceCheckpointType::RACE_NONE && cp->isEnabled()) {
-		return cp->isPlayerInside();
+	IPlayerCheckpointData* playerCheckpointData = player.queryData<IPlayerCheckpointData>();
+	if (playerCheckpointData) {
+		IPlayerRaceCheckpointData& cp = playerCheckpointData->getRaceCheckpoint();
+		if (cp.getType() != RaceCheckpointType::RACE_NONE && cp.isEnabled()) {
+			return cp.isPlayerInside();
+		}
 	}
 	return false;
 }


### PR DESCRIPTION
Now we use radius internally for both types, we handle size type inconsistency in legacy levels (pawn natives and passing data to rpc initializers)
Players can see both types of checkpoints at once now, and "is inside" handling checks for check point being enabled first or not
In order to avoid size issues on client side when SetPlayer(Race)Checkpoint is called twice without disabling, we disable them first if there's an active one