### PR TITLE
Player::setPosition now only sends an rpc, waits for player's pos update from onfoot sync packet

### DIFF
--- a/Server/Source/player_impl.hpp
+++ b/Server/Source/player_impl.hpp
@@ -596,7 +596,8 @@ struct Player final : public IPlayer, public PoolIDProvider, public NoCopy {
     }
 
     void setPosition(Vector3 position) override {
-        pos_ = position;
+        // do not update position internally, let player's position change on their end first
+        // then we receive updates by them when they send on foot sync packets
         NetCode::RPC::SetPlayerPosition setPlayerPosRPC;
         setPlayerPosRPC.Pos = position;
         sendRPC(setPlayerPosRPC);


### PR DESCRIPTION
(fixes #178) Don't set position internally when setpos is used