### PR TITLE
Fix SIGINT freezing on Linux

### DIFF
--- a/Server/Source/server.cpp
+++ b/Server/Source/server.cpp
@@ -17,10 +17,12 @@ void handler(int s)
         core->run_ = false;
     }
 
+#ifdef BUILD_WINDOWS
     // Spin lock until done
     while (!done) {
         std::this_thread::sleep_for(Milliseconds(1));
     }
+#endif
 }
 
 #ifdef BUILD_WINDOWS


### PR DESCRIPTION
This seems to work here, everything gets unloaded properly, as discussed on Discord.