### PR TITLE
Fix Unicode on UNIces - call setlocale to indicate localization support

### DIFF
--- a/Server/Source/server.cpp
+++ b/Server/Source/server.cpp
@@ -69,8 +69,8 @@ int main(int argc, char** argv)
     signal(SIGBREAK, &handler);
     SetUnhandledExceptionFilter(&ExceptionHandler);
     _setmode(_fileno(stdin), _O_U16TEXT);
-    setlocale(LC_ALL, "");
 #endif
+    setlocale(LC_ALL, "");
 
     cxxopts::Options options(argv[0], "The open.mp game server");
 


### PR DESCRIPTION
Locale is set to `C` by default if the application doesn't call `setlocale(LC_ALL, "");` to indicate localization support.