### PR TITLE
Fix getTickCount on UNIX returning time since first call (not server start)

### DIFF
--- a/Server/Source/core_impl.hpp
+++ b/Server/Source/core_impl.hpp
@@ -631,6 +631,8 @@ struct Core final : public ICore, public PlayerEventHandler, public ConsoleEvent
         , ticksThisSecond(0u)
         , EnableLogTimestamp(false)
     {
+        // Initialize start time
+        getTickCount();
         players.getEventDispatcher().addEventHandler(this);
 
         loadComponents("components");


### PR DESCRIPTION
This is happening because start time is initialized on first function
call, meaning that first call always returns 0 and subsequent calls
return ticks since first call.