### PR TITLE
Fix component build output paths on Linux

### DIFF
--- a/Server/CMakeLists.txt
+++ b/Server/CMakeLists.txt
@@ -7,7 +7,7 @@ function(add_server_component name)
 
 	file(GLOB_RECURSE component_source_list "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/*.hpp")
 
-	add_library(${PROJECT_NAME} MODULE ${component_source_list})
+	add_library(${PROJECT_NAME} SHARED ${component_source_list})
 
 	target_link_libraries(${PROJECT_NAME} PRIVATE
 		SDK
@@ -18,7 +18,13 @@ function(add_server_component name)
 
 	set_property(TARGET ${PROJECT_NAME} PROPERTY OUTPUT_NAME ${PROJECT_NAME})
 	set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER "Server/Components")
-	set_property(TARGET ${PROJECT_NAME} PROPERTY LIBRARY_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/components)
+
+	if(MSVC)
+		set_property(TARGET ${PROJECT_NAME} PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/components)
+	else()
+		set_property(TARGET ${PROJECT_NAME} PROPERTY LIBRARY_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/components)
+	endif()
+
 	set_property(TARGET ${PROJECT_NAME} PROPERTY PREFIX "")
 endfunction()
 


### PR DESCRIPTION
And hopefully don't break them for Windows in the process. Please, someone test this there :-)