### PR TITLE
YSF gangzones

### DIFF
--- a/Server/Components/GangZones/gangzone.cpp
+++ b/Server/Components/GangZones/gangzone.cpp
@@ -4,6 +4,7 @@ using namespace Impl;
 
 struct GangZonesComponent final : public IGangZonesComponent, public PlayerUpdateEventHandler {
     ICore* core = nullptr;
+    IPlayerPool* players = nullptr;
     MarkedPoolStorage<GangZone, IGangZone, 0, GANG_ZONE_POOL_SIZE> storage;
     DefaultEventDispatcher<GangZoneEventHandler> eventDispatcher;
 
@@ -20,6 +21,15 @@ struct GangZonesComponent final : public IGangZonesComponent, public PlayerUpdat
     void onLoad(ICore* core) override
     {
         this->core = core;
+        players = &core->getPlayers();
+        players->getPlayerUpdateDispatcher().addEventHandler(this);
+    }
+
+    ~GangZonesComponent()
+    {
+        if (core) {
+            players->getPlayerUpdateDispatcher().removeEventHandler(this);
+        }
     }
 
     bool onUpdate(IPlayer& player, TimePoint now) override

--- a/Server/Components/Pawn/Scripting/Impl.cpp
+++ b/Server/Components/Pawn/Scripting/Impl.cpp
@@ -11,6 +11,7 @@
 #include "Player/Events.hpp"
 #include "TextDraw/Events.hpp"
 #include "Vehicle/Events.hpp"
+#include "GangZone/Events.hpp"
 
 Scripting::~Scripting()
 {
@@ -50,6 +51,9 @@ Scripting::~Scripting()
     }
     if (mgr->console) {
         mgr->console->getEventDispatcher().removeEventHandler(CoreEvents::Get());
+    }
+    if (mgr->gangzones) {
+        mgr->gangzones->getEventDispatcher().removeEventHandler(GangZoneEvents::Get());
     }
 }
 
@@ -91,5 +95,8 @@ void Scripting::addEvents() const
     }
     if (mgr->console) {
         mgr->console->getEventDispatcher().addEventHandler(CoreEvents::Get(), EventPriority_Lowest);
+    }
+    if (mgr->gangzones) {
+        mgr->gangzones->getEventDispatcher().addEventHandler(GangZoneEvents::Get());
     }
 }


### PR DESCRIPTION
Adds YSF gangzone natives (global only for now since player ones are a bit hacky and needs to be discussed)
new natives:
```cpp
native IsValidGangZone(zoneid);
native IsPlayerInGangZone(playerid, zoneid);
native IsGangZoneVisibleForPlayer(playerid, zoneid);
native GangZoneGetColorForPlayer(playerid, zoneid);
native GangZoneGetFlashColorForPlayer(playerid, zoneid);
native IsGangZoneFlashingForPlayer(playerid, zoneid);
native GangZoneGetPos(zoneid, &Float:fMinX, &Float:fMinY = 0.0, &Float:fMaxX = 0.0, &Float:fMaxY = 0.0);
```

new events:
```
forward OnPlayerEnterGangZone(playerid, zoneid);
forward OnPlayerLeaveGangZone(playerid, zoneid);
```