### PR TITLE
Swap around `%x`, `%X`, `%h`, and `%H`.

### DIFF
--- a/Server/Components/Pawn/format.cpp
+++ b/Server/Components/Pawn/format.cpp
@@ -496,14 +496,14 @@ size_t atcprintf(D* buffer, size_t maxlen, const S* format, AMX* amx, const cell
             AddFloat(&buf_p, llen, amx_ctof(*get_amxaddr(amx, params[arg])), width, prec, flags);
             arg++;
             break;
-        case 'X':
+        case 'H':
+        case 'x':
             CHECK_ARGS(0);
             flags |= UPPERDIGITS;
             AddHex(&buf_p, llen, static_cast<unsigned int>(*get_amxaddr(amx, params[arg])), width, flags);
             arg++;
             break;
         case 'h':
-        case 'x':
             CHECK_ARGS(0);
             AddHex(&buf_p, llen, static_cast<unsigned int>(*get_amxaddr(amx, params[arg])), width, flags);
             arg++;


### PR DESCRIPTION
Within SA:MP basically everyone uses `%x` for formatting HEX characters, and that used upper-case letters for `A`-`F`.  The old version of this code changed that behaviour to use lower-case letters and added `%X` for upper-case letters.  Being able to specify lower- or upper-case is good, but we should stay backwards-compatible with as much other code as possible.  This also had `%h` but no `%H` so I switched `%x` to keep historical behaviour and instead use `%h` and `%H` for case specification.