### PR TITLE
Change priority again

### DIFF
--- a/Server/Components/Pawn/Manager/Manager.cpp
+++ b/Server/Components/Pawn/Manager/Manager.cpp
@@ -56,9 +56,9 @@ PawnManager::PawnManager()
 PawnManager::~PawnManager()
 {
     if (mainScript_) {
-		CallInSides("OnGameModeExit", DefaultReturnValue_False);
-		mainScript_->Call("OnGameModeExit", DefaultReturnValue_False);
-		PawnTimerImpl::Get()->killTimers(mainScript_->GetAMX());
+        CallInSides("OnGameModeExit", DefaultReturnValue_False);
+        mainScript_->Call("OnGameModeExit", DefaultReturnValue_False);
+        PawnTimerImpl::Get()->killTimers(mainScript_->GetAMX());
         pluginManager.AmxUnload(mainScript_->GetAMX());
         eventDispatcher.dispatch(&PawnEventHandler::onAmxUnload, mainScript_->GetAMX());
     }


### PR DESCRIPTION
I previously changed the order to:

* Components
* Plugins
* Defaults

The theory being that then components could override any other natives from other places, which is still a good thing.  However, in SA:MP plugins have lower priority than the default natives and it turns out that at least one plugin (sscanf) implicitly relies on this order.  Given that they are legacy anyway, the order should be:

* Components
* Defaults
* Plugins

This does that.

It also calls `OnGameModeExit` in filterscripts when the pawn component shuts down and updates an order change location I missed last time.