### PR TITLE
Fix TextDrawsComponent::componentName typo

### DIFF
--- a/Server/Components/TextDraws/textdraws_main.cpp
+++ b/Server/Components/TextDraws/textdraws_main.cpp
@@ -124,7 +124,7 @@ private:
 public:
     StringView componentName() const override
     {
-        return "TextLabels";
+        return "TextDraws";
     }
 
     SemanticVersion componentVersion() const override


### PR DESCRIPTION
`TextLabels` -> `TextDraws`