### PR TITLE
make PutPlayerInVehicle work if called multiple times

### DIFF
--- a/Server/Components/Vehicles/vehicle.cpp
+++ b/Server/Components/Vehicles/vehicle.cpp
@@ -430,11 +430,6 @@ void Vehicle::putPlayer(IPlayer& player, int SeatID)
     if (vehicleData) {
         auto vehicle = static_cast<Vehicle*>(vehicleData->getVehicle());
 
-        // Player is already in this vehicle and in this seat.
-        if (vehicle == this && SeatID == vehicleData->getSeat()) {
-            return;
-        }
-
         if (vehicle != nullptr) {
             vehicle->unoccupy(player);
             player.setPosition(pos);


### PR DESCRIPTION
We shouldn't check for vehicleid and seat id ourselves internally, it's a change from server side, we can trust server on this one
It's basically problematic when players have high ping, and putting them in vehicle again after failing once won't work cause server thinks they are inside