### PR TITLE
Look up the existing ID first when re-showing a gangzone.

### DIFF
--- a/Server/Components/GangZones/gangzone.hpp
+++ b/Server/Components/GangZones/gangzone.hpp
@@ -96,11 +96,8 @@ public:
 
     void showForPlayer(IPlayer& player, const Colour& colour) override
     {
-		col = colour;
+        col = colour;
         const int playerId = player.getID();
-		if (shownFor_.valid(playerId)) {
-            shownFor_.remove(playerId, player);
-        }
         shownFor_.add(playerId, player);
 
         flashingFor_.reset(playerId);


### PR DESCRIPTION
If you keep re-showing the same gangzone, keep replacing the existing client-side version.