### PR TITLE
`GangZoneDestroy` success return.

### DIFF
--- a/Server/Components/Pawn/Scripting/GangZone/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/GangZone/Natives.cpp
@@ -61,6 +61,7 @@ SCRIPT_API(GangZoneDestroy, bool(int legacyid))
 		{
 			pool->release(realid);
 			pool->releaseLegacyID(legacyid);
+			return true;
 		}
 	}
 


### PR DESCRIPTION
Return `true` when a gang zone is destroyed.