### PR TITLE
Remove internal references to "tower", which isn't a word.

### DIFF
--- a/SDK/include/Server/Components/Vehicles/vehicles.hpp
+++ b/SDK/include/Server/Components/Vehicles/vehicles.hpp
@@ -343,8 +343,8 @@ struct IVehicle : public IExtensible, public IEntity
 	/// Get the current vehicle's attached trailer.
 	virtual IVehicle* getTrailer() const = 0;
 
-	/// Get the current vehicle's tower.
-	virtual IVehicle* getTower() const = 0;
+	/// Get the current vehicle's cab.
+	virtual IVehicle* getCab() const = 0;
 
 	/// Fully repair the vehicle.
 	virtual void repair() = 0;

--- a/Server/Components/Pawn/Scripting/Vehicle/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Vehicle/Natives.cpp
@@ -462,26 +462,26 @@ SCRIPT_API(GetVehicleRespawnDelay, int(IVehicle& vehicle))
 
 SCRIPT_API_FAILRET(GetVehicleCab, INVALID_VEHICLE_ID, int(IVehicle& vehicle))
 {
-	IVehicle* tower = vehicle.getTower();
+	IVehicle* cab = vehicle.getCab();
 
-	if (tower == nullptr)
+	if (cab == nullptr)
 	{
 		return FailRet;
 	}
 
-	return tower->getID();
+	return cab->getID();
 }
 
 SCRIPT_API_FAILRET(GetVehicleTower, INVALID_VEHICLE_ID, int(IVehicle& vehicle))
 {
-	IVehicle* tower = vehicle.getTower();
+	IVehicle* cab = vehicle.getCab();
 
-	if (tower == nullptr)
+	if (cab == nullptr)
 	{
 		return FailRet;
 	}
 
-	return tower->getID();
+	return cab->getID();
 }
 
 SCRIPT_API(GetVehicleOccupiedTick, int(IVehicle& vehicle))

--- a/Server/Components/Pawn/utils.hpp
+++ b/Server/Components/Pawn/utils.hpp
@@ -701,5 +701,6 @@ static const FlatHashMap<String, String> DeprecatedNatives {
 	{ "GetVehiclePoolSize", "MAX_VEHICLES" },
 	{ "GetActorPoolSize", "MAX_ACTORS" },
 	{ "RedirectDownload", "artwork cdn config option" },
-	{ "GetRunningTimers", "CountRunningTimers" }
+	{ "GetRunningTimers", "CountRunningTimers" },
+	{ "GetVehicleTower", "GetVehicleCab" },
 };

--- a/Server/Components/Vehicles/vehicle.cpp
+++ b/Server/Components/Vehicles/vehicle.cpp
@@ -87,17 +87,17 @@ void Vehicle::streamInForPlayer(IPlayer& player)
 		PacketHelper::send(plateRPC, player);
 	}
 
-	// Attempt to attach trailer to tower if both vehicles are streamed in.
-	// We are streaming in the trailer. Check if tower is streamed.
-	if (!towing && tower && tower->isStreamedInForPlayer(player))
+	// Attempt to attach trailer to cab if both vehicles are streamed in.
+	// We are streaming in the trailer. Check if cab is streamed.
+	if (!towing && cab && cab->isStreamedInForPlayer(player))
 	{
 		NetCode::RPC::AttachTrailer trailerRPC;
 		trailerRPC.TrailerID = poolID;
-		trailerRPC.VehicleID = tower->poolID;
+		trailerRPC.VehicleID = cab->poolID;
 		PacketHelper::send(trailerRPC, player);
 	}
 
-	// We are streaming in the tower. Check if trailer is streamed.
+	// We are streaming in the cab. Check if trailer is streamed.
 	if (towing && trailer && trailer->isStreamedInForPlayer(player))
 	{
 		NetCode::RPC::AttachTrailer trailerRPC;
@@ -220,7 +220,7 @@ bool Vehicle::updateFromDriverSync(const VehicleDriverSyncPacket& vehicleSync, I
 		// Client is reporting no trailer (probably lost it) but server thinks there's still one. Detaching it server side.
 		if (trailer && Time::now() - trailer->trailerUpdateTime > Seconds(0))
 		{
-			trailer->tower = nullptr;
+			trailer->cab = nullptr;
 			towing = false;
 			trailer = nullptr;
 		}
@@ -231,7 +231,7 @@ bool Vehicle::updateFromDriverSync(const VehicleDriverSyncPacket& vehicleSync, I
 
 bool Vehicle::updateFromUnoccupied(const VehicleUnoccupiedSyncPacket& unoccupiedSync, IPlayer& player)
 {
-	if (respawning || (isTrailer() && tower->getDriver() != &player))
+	if (respawning || (isTrailer() && cab->getDriver() != &player))
 	{
 		return false;
 	}
@@ -260,10 +260,10 @@ bool Vehicle::updateFromUnoccupied(const VehicleUnoccupiedSyncPacket& unoccupied
 			return handler->onUnoccupiedVehicleUpdate(*this, player, data);
 		});
 
-	if (tower && !towing)
+	if (cab && !towing)
 	{
-		tower->detachTrailer();
-		tower = nullptr;
+		cab->detachTrailer();
+		cab = nullptr;
 	}
 	if (allowed)
 	{
@@ -294,19 +294,19 @@ bool Vehicle::updateFromTrailerSync(const VehicleTrailerSyncPacket& trailerSync,
 	{
 		return false;
 	}
-	else if (tower != vehicle)
+	else if (cab != vehicle)
 	{
-		if (tower && tower->trailer == this)
+		if (cab && cab->trailer == this)
 		{
-			tower->towing = false;
-			tower->trailer = nullptr;
+			cab->towing = false;
+			cab->trailer = nullptr;
 		}
 
 		// Don't call attach RPC here. Client will attach it because trailerId is sent in driver sync.
 		// https://github.com/openmultiplayer/server-beta/issues/181
 		vehicle->trailer = this;
 		vehicle->towing = true;
-		tower = vehicle;
+		cab = vehicle;
 		towing = false;
 		trailerUpdateTime = Time::now();
 	}
@@ -321,7 +321,7 @@ bool Vehicle::updateFromTrailerSync(const VehicleTrailerSyncPacket& trailerSync,
 			// SA:MP will fail to reattach it, so we have to call the attach RPC again.
 			NetCode::RPC::AttachTrailer trailerRPC;
 			trailerRPC.TrailerID = poolID;
-			trailerRPC.VehicleID = tower->poolID;
+			trailerRPC.VehicleID = cab->poolID;
 			PacketHelper::broadcastToSome(trailerRPC, streamedFor_.entries(), &player);
 			trailerUpdateTime = now;
 			printf("rebroadcasted !!\n");
@@ -663,7 +663,7 @@ void Vehicle::respawn()
 	health = 1000.0f;
 	driver = nullptr;
 	trailer = nullptr;
-	tower = nullptr;
+	cab = nullptr;
 	towing = false;
 	detaching = false;
 	params = VehicleParams {};
@@ -690,7 +690,7 @@ void Vehicle::attachTrailer(IVehicle& trailer)
 	}
 	this->trailer = static_cast<Vehicle*>(&trailer);
 	towing = true;
-	this->trailer->setTower(this);
+	this->trailer->setCab(this);
 	this->trailer->trailerUpdateTime = Time::now();
 	NetCode::RPC::AttachTrailer trailerRPC;
 	trailerRPC.TrailerID = this->trailer->poolID;
@@ -705,7 +705,7 @@ void Vehicle::detachTrailer()
 		NetCode::RPC::DetachTrailer trailerRPC;
 		trailerRPC.VehicleID = poolID;
 		PacketHelper::broadcastToSome(trailerRPC, streamedFor_.entries());
-		trailer->setTower(nullptr);
+		trailer->setCab(nullptr);
 		trailer = nullptr;
 		towing = false;
 		detaching = true;
@@ -742,9 +742,9 @@ void Vehicle::setAngularVelocity(Vector3 velocity)
 
 Vehicle::~Vehicle()
 {
-	if (tower)
+	if (cab)
 	{
-		tower->detachTrailer();
+		cab->detachTrailer();
 	}
 	else if (trailer && towing)
 	{

--- a/Server/Components/Vehicles/vehicle.hpp
+++ b/Server/Components/Vehicles/vehicle.hpp
@@ -57,7 +57,7 @@ private:
 	union
 	{
 		Vehicle* trailer = nullptr;
-		Vehicle* tower;
+		Vehicle* cab;
 	};
 	StaticArray<IVehicle*, MAX_VEHICLE_CARRIAGES> carriages;
 	VehicleParams params;
@@ -73,9 +73,9 @@ private:
 		lastOccupiedChange = Time::now();
 	}
 
-	void setTower(Vehicle* tower)
+	void setCab(Vehicle* cab)
 	{
-		this->tower = tower;
+		this->cab = cab;
 		towing = false;
 	}
 
@@ -341,7 +341,7 @@ public:
 	void detachTrailer() override;
 
 	/// Checks if the current vehicle is a trailer.
-	bool isTrailer() const override { return !towing && tower != nullptr; }
+	bool isTrailer() const override { return !towing && cab != nullptr; }
 
 	/// Get the current vehicle's attached trailer.
 	IVehicle* getTrailer() const override
@@ -353,14 +353,14 @@ public:
 		return trailer;
 	}
 
-	/// Get the current vehicle's tower.
-	IVehicle* getTower() const override
+	/// Get the current vehicle's cab.
+	IVehicle* getCab() const override
 	{
 		if (towing)
 		{
 			return nullptr;
 		}
-		return tower;
+		return cab;
 	}
 
 	/// Adds a train carriage to the vehicle (ONLY FOR TRAINS).


### PR DESCRIPTION
"tower" as in "thing that tows" not "large thin building", which is confusing, hence using "cab" instead.