### PR TITLE
Ablility to use :memory: and URI filename in db_open

### DIFF
--- a/Server/Components/Pawn/Scripting/Database/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Database/Natives.cpp
@@ -13,14 +13,14 @@
 
 SCRIPT_API(db_open, int(const std::string& name))
 {
-	ghc::filesystem::path dbFilePath = ghc::filesystem::absolute("scriptfiles/" + name);
-	IDatabaseConnection* database_connection(PawnManager::Get()->databases->open(dbFilePath.string()));
-	return database_connection ? database_connection->getID() : 0;
-}
+	bool inMemoryOrURI = false;
+	if (name.find(":memory:") == 0 || name.find("file:") == 0)
+	{
+		inMemoryOrURI = true;
+	}
 
-SCRIPT_API(db_open_raw, int(const std::string& name))
-{
-	IDatabaseConnection* database_connection(PawnManager::Get()->databases->open(name));
+	ghc::filesystem::path dbFilePath = ghc::filesystem::absolute("scriptfiles/" + name);
+	IDatabaseConnection* database_connection(PawnManager::Get()->databases->open(inMemoryOrURI ? name : dbFilePath.string()));
 	return database_connection ? database_connection->getID() : 0;
 }
 
@@ -129,14 +129,14 @@ SCRIPT_API(db_debug_openresults, int())
 
 SCRIPT_API(DB_Open, int(const std::string& name))
 {
-	ghc::filesystem::path dbFilePath = ghc::filesystem::absolute("scriptfiles/" + name);
-	IDatabaseConnection* database_connection(PawnManager::Get()->databases->open(dbFilePath.string()));
-	return database_connection ? database_connection->getID() : 0;
-}
+	bool inMemoryOrURI = false;
+	if (name.find(":memory:") == 0 || name.find("file:") == 0)
+	{
+		inMemoryOrURI = true;
+	}
 
-SCRIPT_API(DB_OpenRaw, int(const std::string& name))
-{
-	IDatabaseConnection* database_connection(PawnManager::Get()->databases->open(name));
+	ghc::filesystem::path dbFilePath = ghc::filesystem::absolute("scriptfiles/" + name);
+	IDatabaseConnection* database_connection(PawnManager::Get()->databases->open(inMemoryOrURI ? name : dbFilePath.string()));
 	return database_connection ? database_connection->getID() : 0;
 }
 


### PR DESCRIPTION
Ablility to use :memory: and URI filename in db_open.
for example: `db_open("file::memory:?cache=shared")` to have a shared-cached in-memory database