### PR TITLE
Switch to using bitset2.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "lib/cpp-httplib"]
 	path = lib/cpp-httplib
 	url = git@github.com:ksenonadv/cpp-httplib.git
+[submodule "SDK/lib/bitset2"]
+	path = SDK/lib/bitset2
+	url = https://github.com/openmultiplayer/bitset2.git

--- a/SDK/CMakeLists.txt
+++ b/SDK/CMakeLists.txt
@@ -51,6 +51,7 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
 endif()
 
 target_include_directories(OMP-SDK INTERFACE include/)
+target_include_directories(OMP-SDK INTERFACE lib/)
 
 file(GLOB_RECURSE omp_sdk_source_list "*.hpp")
 

--- a/SDK/include/types.hpp
+++ b/SDK/include/types.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <array>
-#include <bitset>
+#include <stdexcept>
+#include <bitset2/bitset2.hpp>
 #include <chrono>
 #include <cstdint>
 #include <glm/vec2.hpp>
@@ -72,7 +73,7 @@ namespace Impl
 using String = std::string;
 
 template <size_t Size>
-using StaticBitset = std::bitset<Size>;
+using StaticBitset = Bitset2::bitset2<Size, unsigned long long>;
 
 }
 

--- a/SDK/include/types.hpp
+++ b/SDK/include/types.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <array>
+#if !defined OMP_NO_EXCEPTIONS
 #include <stdexcept>
 #include <bitset2/bitset2.hpp>
+#endif
 #include <chrono>
 #include <cstdint>
 #include <glm/vec2.hpp>
@@ -69,12 +71,12 @@ using std::chrono::duration_cast;
 /// Don't pass these around the SDK
 namespace Impl
 {
-
 using String = std::string;
 
+#if !defined OMP_NO_EXCEPTIONS
 template <size_t Size>
 using StaticBitset = Bitset2::bitset2<Size, unsigned long long>;
-
+#endif
 }
 
 template <typename T>

--- a/Server/Components/Unicode/CMakeLists.txt
+++ b/Server/Components/Unicode/CMakeLists.txt
@@ -4,6 +4,11 @@ add_server_component(${ProjectId})
 if (STATIC_STDCXX)
 	# Remove any possible symbols from ICU, lower GLIBCXX version to 3.4.11
 	target_compile_options(${ProjectId} PRIVATE -fno-exceptions -fno-rtti)
+
+	target_compile_definitions(${ProjectId} PRIVATE
+		OMP_NO_EXCEPTIONS=1
+		OMP_NO_RTTI=1
+	)
 endif()
 
 target_link_libraries(${ProjectId} PRIVATE


### PR DESCRIPTION
This doesn't make a difference at this stage, but is a precursor to some other changes intended to generally improve memory consumption.  Most importantly bitset2 has one very important new function - `find_first`.  It isn't quite as efficient as my method was (see Hacker's Delight, ISBN  9780201914658), but I've forked the original project so we can add internal improvements as we need.