### PR TITLE
Component load pr

### DIFF
--- a/Server/Source/core_impl.hpp
+++ b/Server/Source/core_impl.hpp
@@ -998,7 +998,6 @@ private:
 						p.replace_extension(LIBRARY_EXT);
 					}
 
-					printLn("Loading component %s", p.filename().c_str());
 					IComponent* component = loadComponent(p);
 					if (component)
 					{


### PR DESCRIPTION
Two small improvements to component loading:

1. Adds `"exclude":` to the top level of the JSON so you can explicitly not load certain components.  Especially when testing I would frequently have to list all the components and remove one just to load all but one:

```json
{
    "exclude": [ "Vehicles" ]
}
```

2. Gives a message when a component listed in `"components":` doesn't exist:

```json
{
    "components": [ "Checkpoints", "GongZones", "Variables" ]
}
```

Now gives an error instead of silently failing.