### PR TITLE
Actually ignore missing `main`, like the comment says.

### DIFF
--- a/Server/Components/Pawn/Manager/Manager.cpp
+++ b/Server/Components/Pawn/Manager/Manager.cpp
@@ -551,7 +551,7 @@ bool PawnManager::Load(std::string const& name, bool isEntryScript)
 				amx->reset_hea,
 			};
 		}
-		else
+		else if (err != AMX_ERR_NOTFOUND)
 		{
 			// If there's no `main` ignore it for now.
 			core->logLn(LogLevel::Error, "%s", aux_StrError(err));


### PR DESCRIPTION
Don't give an error when a script starts without `main()`.