### PR TITLE
Fix submodules URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,18 @@
 [submodule "lib/pawn"]
 	path = lib/pawn
-	url = git@github.com:openmultiplayer/compiler.git
+	url = https://github.com/openmultiplayer/compiler.git
 [submodule "lib/pawn-natives"]
 	path = lib/pawn-natives
-	url = git@github.com:openmultiplayer/pawn-natives.git
+	url = https://github.com/openmultiplayer/pawn-natives.git
 [submodule "lib/RakNet"]
 	path = lib/RakNet
-	url = git@github.com:openmultiplayer/RakNet.git
+	url = https://github.com/openmultiplayer/RakNet.git
 [submodule "lib/ttmath"]
 	path = lib/ttmath
-	url = git@github.com:openmultiplayer/ttmath.git
+	url = https://github.com/openmultiplayer/ttmath.git
 [submodule "SDK/lib/cmake-conan"]
 	path = SDK/lib/cmake-conan
-	url = git@github.com:openmultiplayer/cmake-conan.git
+	url = https://github.com/openmultiplayer/cmake-conan.git
 [submodule "lib/cpp-httplib"]
 	path = lib/cpp-httplib
-	url = git@github.com:ksenonadv/cpp-httplib.git
+	url = https://github.com/ksenonadv/cpp-httplib.git


### PR DESCRIPTION
HTTPS versions of URLs should be used instead of SSH, as if you're not a maintainer (i.e. do not have a write permission in repository), recursive cloning results with the following for all the submodules:

```
Cloning into 'E:/Other/Builds/open.mp/SDK/lib/cmake-conan'...
FATAL ERROR: No supported authentication methods available (server sent: publickey)
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```