### PR TITLE
Fix `GetVehicleLastDriver` returning 0 when invalid `vehicleid` is passed

### DIFF
--- a/Server/Components/Pawn/Scripting/Vehicle/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Vehicle/Natives.cpp
@@ -529,7 +529,7 @@ SCRIPT_API(IsVehicleSirenEnabled, bool(IVehicle& vehicle))
 	return vehicle.getSpawnData().siren;
 }
 
-SCRIPT_API(GetVehicleLastDriver, int(IVehicle& vehicle))
+SCRIPT_API_FAILRET(GetVehicleLastDriver, INVALID_PLAYER_ID, int(IVehicle& vehicle))
 {
 	return vehicle.getLastDriverPoolID();
 }


### PR DESCRIPTION
Issue #614 fix