### PR TITLE
Use per-player color on player stream in

### DIFF
--- a/Server/Source/player.cpp
+++ b/Server/Source/player.cpp
@@ -244,9 +244,16 @@ void Player::streamInForPlayer(IPlayer& other)
 			{
 				playerStreamInRPC.CustomSkin = models_data->getCustomSkin();
 			}
+			
+			Colour colour;
+			bool hasPlayerSpecificColour = other.getOtherColour(*this, colour);
+			if (!hasPlayerSpecificColour)
+			{
+				colour = colour_;
+			}
 
 			playerStreamInRPC.Team = team_;
-			playerStreamInRPC.Col = colour_;
+			playerStreamInRPC.Col = colour;
 			playerStreamInRPC.Pos = pos_;
 			playerStreamInRPC.Angle = rot_.ToEuler().z;
 			playerStreamInRPC.FightingStyle = fightingStyle_;

--- a/Server/Source/player.cpp
+++ b/Server/Source/player.cpp
@@ -244,7 +244,7 @@ void Player::streamInForPlayer(IPlayer& other)
 			{
 				playerStreamInRPC.CustomSkin = models_data->getCustomSkin();
 			}
-			
+
 			Colour colour;
 			bool hasPlayerSpecificColour = other.getOtherColour(*this, colour);
 			if (!hasPlayerSpecificColour)


### PR DESCRIPTION
Fixes per-player color reverting back to global one clientside when the other player streams in