### PR TITLE
Add more relevant items to BrokenPlugins list

### DIFF
--- a/Server/Components/Pawn/PluginManager/PluginManager.cpp
+++ b/Server/Components/Pawn/PluginManager/PluginManager.cpp
@@ -16,7 +16,7 @@ struct BrokenPluginMessageData
 	StringView message;
 };
 
-static const StaticArray<BrokenPluginMessageData, 15> BrokenPlugins = {
+static const StaticArray<BrokenPluginMessageData, 20> BrokenPlugins = {
 	{
 		{ "YSF", "It requires memory hacking to run and is therefore broken on open.mp, we already added many built-in features from YSF to open.mp and the rest are coming" },
 		{ "YSF_DL", "It requires memory hacking to run and is therefore broken on open.mp, we already added many built-in features from YSF to open.mp and the rest are coming" },
@@ -33,6 +33,11 @@ static const StaticArray<BrokenPluginMessageData, 15> BrokenPlugins = {
 		{ "ASAN", "It requires memory hacking to run and is therefore broken on open.mp. There should be a replacement component supported by open.mp" },
 		{ "nativechecker", "It is not needed anymore since open.mp has built in native checking mechanism when a script is being loaded" },
 		{ "samp-compat", "It is not needed anymore since open.mp has built in compat mechanism between 0.3.7 and 0.3DL versions" },
+		{ "LFN", "It is not needed anymore since open.mp has support for longer function names, just compile your scripts with our compiler" },
+		{ "samp-custom-query-flood-check", "It requires memory hacking to run and is therefore broken on open.mp. There should be a replacement component supported by open.mp" },
+		{ "AntiVehicleSpawn", "It requires memory hacking to run and is therefore broken on open.mp. There should be a replacement component supported by open.mp" },
+		{ "mcmd", "It requires memory hacking to run and is therefore broken on open.mp. There should be a replacement component supported by open.mp" },
+		{ "raktimefix", "It is not needed anymore since open.mp has no stability issues on the latest linux systems" },
 	}
 };
 

--- a/Server/Components/Pawn/PluginManager/PluginManager.cpp
+++ b/Server/Components/Pawn/PluginManager/PluginManager.cpp
@@ -16,7 +16,7 @@ struct BrokenPluginMessageData
 	StringView message;
 };
 
-static const StaticArray<BrokenPluginMessageData, 20> BrokenPlugins = {
+static const StaticArray<BrokenPluginMessageData, 23> BrokenPlugins = {
 	{
 		{ "YSF", "It requires memory hacking to run and is therefore broken on open.mp, we already added many built-in features from YSF to open.mp and the rest are coming" },
 		{ "YSF_DL", "It requires memory hacking to run and is therefore broken on open.mp, we already added many built-in features from YSF to open.mp and the rest are coming" },
@@ -38,6 +38,9 @@ static const StaticArray<BrokenPluginMessageData, 20> BrokenPlugins = {
 		{ "AntiVehicleSpawn", "It requires memory hacking to run and is therefore broken on open.mp. There should be a replacement component supported by open.mp" },
 		{ "mcmd", "It requires memory hacking to run and is therefore broken on open.mp. There should be a replacement component supported by open.mp" },
 		{ "raktimefix", "It is not needed anymore since open.mp has no stability issues on the latest linux systems" },
+		{ "KeyListener", "It requires memory hacking to run and is therefore broken on open.mp. There should be a replacement component supported by open.mp" },
+		{ "chandlingsvr", "It requires memory hacking to run and is therefore broken on open.mp. There should be a replacement component supported by open.mp" },
+		{ "samp_akm", "It requires memory hacking to run and is therefore broken on open.mp. There should be a replacement component supported by open.mp" },
 	}
 };
 


### PR DESCRIPTION
I found some relevant memhack plugins to add in a warning list, they are:
* [Long Function Names](https://github.com/IS4Code/LFN) (omp server & compiler already has this feature)
* [CQFC plugin](https://github.com/spmn/samp-custom-query-flood-check) (even if omp has better query flood checking, the message is the default as for any unsupported memhack plugin because it also provided pawn callback to apply your own rules, so, couldn't be shown "not needed anymore because it's working now correctly by default")
* [AntiVehicleSpawn](https://github.com/povargek/AntiVehicleSpawn) (hooks vehicle death event, was on samp forums and gained some popularity before Pawn.RakNet become more popular alternative to re-implement its functional)
* [mcmd](https://github.com/Mellnik/mcmd) (released on samp forums, not supported as it's not adapted to omp sdk)
* [raktimefix](https://github.com/vsergeenko777/samp-plugin-raktimefix) (omp has no described issues, neither need a memhacking fix for them)
* [KeyListener](https://github.com/CyberMor/keylistener) (just like the serverside part of sampvoice or sampcac it uses memhack, but not adapted at the moment)
* [CHandling](https://github.com/dotSILENT/chandling-svr) (just like the serverside part of sampvoice or sampcac it uses memhack, but not adapted at the moment)
* [AuthKeyModifier](https://github.com/dotSILENT/samp-akm) (less relevant than others proposed, but it's for latest samp server version and thus it still can be used by some people)