### PR TITLE
Fixed possibility to load the same script more than once.

### DIFF
--- a/Server/Components/Pawn/Manager/Manager.cpp
+++ b/Server/Components/Pawn/Manager/Manager.cpp
@@ -267,7 +267,7 @@ void PawnManager::CheckNatives(PawnScript& script)
 bool PawnManager::Changemode(std::string const& name)
 {
 	std::string normal_script_name;
-	utils::NormalizeScriptName(name, normal_script_name);
+	utils::NormaliseScriptName(name, normal_script_name);
 
 	// First check that the new script exists.
 	FILE* fp;
@@ -542,7 +542,7 @@ void PawnManager::openAMX(PawnScript& script, bool isEntryScript)
 bool PawnManager::Load(std::string const& name, bool isEntryScript)
 {
 	std::string normal_script_name;
-	utils::NormalizeScriptName(name, normal_script_name);
+	utils::NormaliseScriptName(name, normal_script_name);
 
 	if (mainName_ == normal_script_name)
 	{
@@ -646,7 +646,7 @@ is `2`.
 bool PawnManager::Reload(std::string const& name)
 {
 	std::string normal_script_name;
-	utils::NormalizeScriptName(name, normal_script_name);
+	utils::NormaliseScriptName(name, normal_script_name);
 
 	// Entry script reload is not supported.
 	if (mainName_ == normal_script_name)
@@ -671,7 +671,7 @@ bool PawnManager::Reload(std::string const& name)
 bool PawnManager::Unload(std::string const& name)
 {
 	std::string normal_script_name;
-	utils::NormalizeScriptName(name, normal_script_name);
+	utils::NormaliseScriptName(name, normal_script_name);
 
 	auto pos = findScript(normal_script_name);
 	bool isEntryScript = mainName_ == normal_script_name;

--- a/Server/Components/Pawn/utils.hpp
+++ b/Server/Components/Pawn/utils.hpp
@@ -804,21 +804,6 @@ inline bool Canonicalise(std::string path, std::string& result)
 	return ret;
 }
 
-inline bool CanonicaliseScriptName(const std::string& name, std::string& result)
-{
-	if (utils::Canonicalise(name, result))
-	{
-		// if the user just supplied a script name, add the extension
-		// otherwise, don't, as they may have supplied a full abs/rel path.
-		if (!utils::endsWith(result, ".amx"))
-		{
-			result.append(".amx");
-		}
-		return true;
-	}
-	return false;
-}
-
 inline bool GetCurrentWorkingDirectory(std::string& result)
 {
 	result.clear();
@@ -866,6 +851,22 @@ inline bool GetCurrentWorkingDirectory(std::string& result)
 }
 
 #endif
+	
+inline bool CanonicaliseScriptName(const std::string& name, std::string& result)
+{
+	if (utils::Canonicalise(name, result))
+	{
+		// if the user just supplied a script name, add the extension
+		// otherwise, don't, as they may have supplied a full abs/rel path.
+		if (!utils::endsWith(result, ".amx"))
+		{
+			result.append(".amx");
+		}
+		return true;
+	}
+	return false;
+}
+	
 }
 
 static const FlatHashMap<String, String> DeprecatedNatives {

--- a/Server/Components/Pawn/utils.hpp
+++ b/Server/Components/Pawn/utils.hpp
@@ -849,24 +849,30 @@ inline bool GetCurrentWorkingDirectory(std::string& result)
 	}
 	return ret;
 }
-
 #endif
-	
-inline bool CanonicaliseScriptName(const std::string& name, std::string& result)
+inline void NormalizeScriptName(std::string name, std::string& result)
 {
-	if (utils::Canonicalise(name, result))
+#ifdef WIN32
+	constexpr auto wrong_slash = '/';
+	constexpr auto right_slash = '\\';
+#else
+	constexpr auto wrong_slash = '\\';
+	constexpr auto right_slash = '/';
+#endif
+	size_t pos = 0;
+	while ((pos = name.find(wrong_slash, pos)) != std::string::npos)
 	{
-		// if the user just supplied a script name, add the extension
-		// otherwise, don't, as they may have supplied a full abs/rel path.
-		if (!utils::endsWith(result, ".amx"))
-		{
-			result.append(".amx");
-		}
-		return true;
+		name.replace(pos, 1, 1, right_slash);
 	}
-	return false;
+
+	if (!utils::endsWith(name, ".amx"))
+	{
+		name.append(".amx");
+	}
+
+	result = name;
+	return;
 }
-	
 }
 
 static const FlatHashMap<String, String> DeprecatedNatives {

--- a/Server/Components/Pawn/utils.hpp
+++ b/Server/Components/Pawn/utils.hpp
@@ -64,6 +64,11 @@ inline bool endsWith(const std::string& mainStr, const std::string& toMatch)
 		return false;
 }
 
+inline bool endsWith(const std::string& mainStr, const char toMatch)
+{
+	return mainStr.rbegin() != mainStr.rend() && *mainStr.rbegin() == toMatch;
+}
+
 inline cell AMX_NATIVE_CALL pawn_format(AMX* amx, cell const* params)
 {
 	int
@@ -852,7 +857,7 @@ inline bool GetCurrentWorkingDirectory(std::string& result)
 #endif
 inline void NormalizeScriptName(std::string name, std::string& result)
 {
-#ifdef WIN32
+#if defined(_WIN32) || defined(WIN32) || defined(__WIN32__) || defined(_WIN64) || defined(WIN64) || defined(__WIN64__)
 	constexpr auto wrong_slash = '/';
 	constexpr auto right_slash = '\\';
 #else
@@ -865,7 +870,7 @@ inline void NormalizeScriptName(std::string name, std::string& result)
 		name.replace(pos, 1, 1, right_slash);
 	}
 
-	if (name.rbegin() != name.rend() && *name.rbegin() != right_slash && !utils::endsWith(name, ".amx"))
+	if (!utils::endsWith(name, right_slash) && !utils::endsWith(name, ".amx"))
 	{
 		name.append(".amx");
 	}

--- a/Server/Components/Pawn/utils.hpp
+++ b/Server/Components/Pawn/utils.hpp
@@ -855,7 +855,7 @@ inline bool GetCurrentWorkingDirectory(std::string& result)
 	return ret;
 }
 #endif
-inline void NormalizeScriptName(std::string name, std::string& result)
+inline void NormaliseScriptName(std::string name, std::string& result)
 {
 #if defined(_WIN32) || defined(WIN32) || defined(__WIN32__) || defined(_WIN64) || defined(WIN64) || defined(__WIN64__)
 	constexpr auto wrong_slash = '/';

--- a/Server/Components/Pawn/utils.hpp
+++ b/Server/Components/Pawn/utils.hpp
@@ -804,7 +804,7 @@ inline bool Canonicalise(std::string path, std::string& result)
 	return ret;
 }
 
-inline bool CanonicaliseScriptName(const std::string &name, std::string& result)
+inline bool CanonicaliseScriptName(const std::string& name, std::string& result)
 {
 	if (utils::Canonicalise(name, result))
 	{

--- a/Server/Components/Pawn/utils.hpp
+++ b/Server/Components/Pawn/utils.hpp
@@ -804,6 +804,21 @@ inline bool Canonicalise(std::string path, std::string& result)
 	return ret;
 }
 
+inline bool CanonicaliseScriptName(const std::string &name, std::string& result)
+{
+	if (utils::Canonicalise(name, result))
+	{
+		// if the user just supplied a script name, add the extension
+		// otherwise, don't, as they may have supplied a full abs/rel path.
+		if (!utils::endsWith(result, ".amx"))
+		{
+			result.append(".amx");
+		}
+		return true;
+	}
+	return false;
+}
+
 inline bool GetCurrentWorkingDirectory(std::string& result)
 {
 	result.clear();

--- a/Server/Components/Pawn/utils.hpp
+++ b/Server/Components/Pawn/utils.hpp
@@ -865,7 +865,7 @@ inline void NormalizeScriptName(std::string name, std::string& result)
 		name.replace(pos, 1, 1, right_slash);
 	}
 
-	if (!utils::endsWith(name, ".amx"))
+	if (name.rbegin() != name.rend() && *name.rbegin() != right_slash && !utils::endsWith(name, ".amx"))
 	{
 		name.append(".amx");
 	}


### PR DESCRIPTION
User could load the same script more than once the following ways:

1) load script with and without extension
```
loadfs test_script
loadfs test_script.amx
```

2) load script by command `loadscript` with rel. path to script that contains different slashes, e.g.
```
loadscript filterscripts/test_script
loadscript filterscripts\test_script
```

Added new function `utils::CanonicaliseScriptName()` that canonized path to script and adds an extension to the name of the script if it is missing. This ensures that the `PawnScript::name_` will always contain the name + extension of script.