### PR TITLE
Fix custom rules getting overridden by automatic values every tick.

### DIFF
--- a/SDK/include/network.hpp
+++ b/SDK/include/network.hpp
@@ -371,6 +371,30 @@ struct INetworkQueryExtension : public IExtension
 	virtual bool isValidRule(StringView rule) = 0;
 };
 
+static const UID QueryRulesExtension_UID = UID(0xBC2B6AB9E411D4FB);
+struct IQueryRulesExtension : public IExtension
+{
+	PROVIDE_EXT_UID(QueryRulesExtension_UID);
+
+	/// Check if a rule is customised.
+	virtual bool isCustomRule(StringView rule) const = 0;
+
+	/// Check if a rule is deleted.
+	virtual bool isRemovedRule(StringView rule) const = 0;
+
+	/// Check if a rule is protected.
+	virtual bool isProtectedRule(StringView rule) const = 0;
+
+	/// Remove the `custom` flag on a rule.
+	virtual bool resetRule(StringView rule) = 0;
+
+	/// Add a rule to the protected list.  This can never be reversed.
+	virtual bool protectRule(StringView rule) = 0;
+
+	/// Remove a rule from the network rules
+	virtual const StringView getRule(StringView rule) const = 0;
+};
+
 /// Peer network data
 struct PeerNetworkData
 {

--- a/Server/Components/LegacyNetwork/Query/query.hpp
+++ b/Server/Components/LegacyNetwork/Query/query.hpp
@@ -116,7 +116,7 @@ public:
 			customs.emplace(String(ruleName));
 		}
 	}
-	
+
 	void resetRule(StringView ruleName)
 	{
 		customs.erase(String(ruleName));
@@ -138,7 +138,7 @@ public:
 		String key { ruleName };
 		return rules.find(key) == rules.end() && customs.find(key) != customs.end();
 	}
-	
+
 	String getRule(StringView ruleName) const
 	{
 		String key { ruleName };

--- a/Server/Components/LegacyNetwork/Query/query.hpp
+++ b/Server/Components/LegacyNetwork/Query/query.hpp
@@ -116,22 +116,38 @@ public:
 			customs.emplace(String(ruleName));
 		}
 	}
+	
+	void resetRule(StringView ruleName)
+	{
+		customs.erase(String(ruleName));
+	}
 
-	bool isValidRule(StringView ruleName)
+	bool isValidRule(StringView ruleName) const
 	{
 		return rules.find(String(ruleName)) != rules.end();
 	}
 
-	bool isCustomRule(StringView ruleName)
+	bool isCustomRule(StringView ruleName) const
 	{
 		return customs.find(String(ruleName)) != customs.end();
 	}
 
-	bool isRemovedRule(StringView ruleName)
+	bool isRemovedRule(StringView ruleName) const
 	{
 		// The rule is deleted if it isn't valid but is customised.
 		String key { ruleName };
 		return rules.find(key) == rules.end() && customs.find(key) != customs.end();
+	}
+	
+	String getRule(StringView ruleName) const
+	{
+		String key { ruleName };
+		auto const& it = rules.find(key);
+		if (it == rules.end())
+		{
+			return String();
+		}
+		return it->second;
 	}
 
 	void setServerName(StringView value)

--- a/Server/Components/LegacyNetwork/legacy_network_impl.cpp
+++ b/Server/Components/LegacyNetwork/legacy_network_impl.cpp
@@ -686,6 +686,12 @@ NetworkStats RakNetLegacyNetwork::getStatistics(IPlayer* player)
 	return stats;
 }
 
+void RakNetLegacyNetwork::reset()
+{
+	// Clear the rules that update every tick.
+	query.resetRules();
+}
+
 void RakNetLegacyNetwork::update()
 {
 	IConfig& config = core->getConfig();

--- a/Server/Components/LegacyNetwork/legacy_network_impl.hpp
+++ b/Server/Components/LegacyNetwork/legacy_network_impl.hpp
@@ -343,12 +343,12 @@ public:
 	{
 		return query.isValidRule(rule);
 	}
-	
+
 	bool isCustomRule(StringView rule) const override
 	{
 		return query.isCustomRule(rule);
 	}
-	
+
 	bool isRemovedRule(StringView rule) const override
 	{
 		return query.isRemovedRule(rule);
@@ -375,12 +375,12 @@ public:
 		}
 		return false;
 	}
-	
+
 	const StringView getRule(StringView rule) const override
 	{
 		return query.getRule(rule);
 	}
-	
+
 	bool protectRule(StringView rule) override
 	{
 		if (isProtectedRule(rule))

--- a/Server/Components/LegacyNetwork/legacy_network_impl.hpp
+++ b/Server/Components/LegacyNetwork/legacy_network_impl.hpp
@@ -322,7 +322,7 @@ public:
 			return false;
 		}
 
-		query.setRuleValue(String(rule), String(value));
+		query.setRuleValue(rule, value, true);
 		query.buildRulesBuffer();
 		return true;
 	}
@@ -376,9 +376,7 @@ public:
 	void ban(const BanEntry& entry, Milliseconds expire = Milliseconds(0)) override;
 	void unban(const BanEntry& entry) override;
 
-	void reset() override
-	{
-	}
+	void reset() override;
 };
 
 struct AnnounceHTTPResponseHandler final : HTTPResponseHandler

--- a/Server/Components/Pawn/Scripting/Core/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Core/Natives.cpp
@@ -888,6 +888,21 @@ SCRIPT_API(SetServerRule, bool(const std::string& name, cell const* format))
 	return false;
 }
 
+SCRIPT_API(ResetServerRule, bool(const std::string& name))
+{
+	if (ICore* core = PawnManager::Get()->core)
+	{
+		for (INetwork* network : core->getNetworks())
+		{
+			if (IQueryRulesExtension* query = queryExtension<IQueryRulesExtension>(network))
+			{
+				return query->resetRule(name);
+			}
+		}
+	}
+	return false;
+}
+
 SCRIPT_API(IsValidServerRule, bool(const std::string& name))
 {
 	ICore* core = PawnManager::Get()->core;
@@ -903,6 +918,91 @@ SCRIPT_API(IsValidServerRule, bool(const std::string& name))
 		if (query)
 		{
 			return query->isValidRule(name);
+		}
+	}
+	return false;
+}
+
+SCRIPT_API(IsCustomServerRule, bool(const std::string& name))
+{
+	if (ICore* core = PawnManager::Get()->core)
+	{
+		for (INetwork* network : core->getNetworks())
+		{
+			if (IQueryRulesExtension* query = queryExtension<IQueryRulesExtension>(network))
+			{
+				return query->isCustomRule(name);
+			}
+		}
+	}
+	return false;
+}
+
+SCRIPT_API(IsRemovedServerRule, bool(const std::string& name))
+{
+	if (ICore* core = PawnManager::Get()->core)
+	{
+		for (INetwork* network : core->getNetworks())
+		{
+			if (IQueryRulesExtension* query = queryExtension<IQueryRulesExtension>(network))
+			{
+				if (query->isRemovedRule(name))
+				{
+					return true;
+				}
+			}
+		}
+	}
+	return false;
+}
+
+SCRIPT_API(IsProtectedServerRule, bool(const std::string& name))
+{
+	if (ICore* core = PawnManager::Get()->core)
+	{
+		for (INetwork* network : core->getNetworks())
+		{
+			if (IQueryRulesExtension* query = queryExtension<IQueryRulesExtension>(network))
+			{
+				return query->isProtectedRule(name);
+			}
+		}
+	}
+	return false;
+}
+
+SCRIPT_API(ProtectServerRule, bool(const std::string& name))
+{
+	if (ICore* core = PawnManager::Get()->core)
+	{
+		for (INetwork* network : core->getNetworks())
+		{
+			if (IQueryRulesExtension* query = queryExtension<IQueryRulesExtension>(network))
+			{
+				return query->protectRule(name);
+			}
+		}
+	}
+	return false;
+}
+
+SCRIPT_API(GetServerRule, bool(const std::string& name, OutputOnlyString& value))
+{
+	if (ICore* core = PawnManager::Get()->core)
+	{
+		for (INetwork* network : core->getNetworks())
+		{
+			if (INetworkQueryExtension* a = queryExtension<INetworkQueryExtension>(network))
+			{
+				if (a->isValidRule(name))
+				{
+					if (IQueryRulesExtension* b = queryExtension<IQueryRulesExtension>(network))
+					{
+						value = b->getRule(name);
+						return true;
+					}
+				}
+			}
 		}
 	}
 	return false;


### PR DESCRIPTION
This keeps a set of keys that have had a custom value given, and if a key is found in that set only a new custom value can be assigned to it - it can't be auto-assigned.  Deleting a variable is also customising it so this flag is set in that case as well, which gives the interesting property that we can find deleted keys by checking if they are customised but don't exist.

Also, adding queries used to use a templated function with variable arguments, but then immediately assumed the parameters were convertible to strings.  There was nothing to enforce this in the signature and none of the calls took advantage of this in any way so I just removed it and used two `StringView` parameters.

Also now adds a load of new functions to the query rules system:

* `ResetServerRule` - Used after setting a custom value to return the rule to an automatically set state.
* `IsCustomServerRule` - `true` for rules set by script, `false` for those set by the server.
* `IsRemovedServerRule` - `true` for deleted rules.
* `IsProtectedServerRule` - `true` for rules that can't be modified.
* `ProtectServerRule` - Mark a rule as protected.  Once set can never be unset (that would defeat the object of protection).
* `GetServerRule` - Return the string value of a rule.