### PR TITLE
Ported several functions missed out from fixes.inc.

### DIFF
--- a/SDK/include/player.hpp
+++ b/SDK/include/player.hpp
@@ -1028,4 +1028,7 @@ struct IPlayerPool : public IExtensible, public IReadOnlyPool<IPlayer>
 
 	/// Check if a specific character is allowed to be used in player names.
 	virtual bool isNickNameCharacterAllowed(char character) const = 0;
+
+	/// Get the colour assigned to a player ID when it first connects.
+	virtual Colour getDefaultColour(int pid) const = 0;
 };

--- a/Server/Components/Pawn/Scripting/Core/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Core/Natives.cpp
@@ -15,6 +15,7 @@
 #include <iomanip>
 #include <math.h>
 #include <sstream>
+#include <anim.hpp>
 
 SCRIPT_API(GetTickCount, int())
 {
@@ -209,6 +210,12 @@ SCRIPT_API(EnableAllAnimations, bool(bool allow))
 {
 	*PawnManager::Get()->config->getBool("game.use_all_animations") = allow;
 	return true;
+}
+
+SCRIPT_API(IsValidAnimationLibrary, bool(std::string const& name))
+{
+	cell* args = GetParams();
+	return animationLibraryValid(name, args[0] == 1 * sizeof(cell) || args[2]);
 }
 
 SCRIPT_API(AreInteriorWeaponsAllowed, bool())

--- a/Server/Components/Pawn/Scripting/Player/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Player/Natives.cpp
@@ -214,6 +214,12 @@ SCRIPT_API(GetPlayerColor, int(IPlayer& player))
 	return player.getColour().RGBA();
 }
 
+SCRIPT_API(GetDefaultPlayerColour, int(int pid))
+{
+	// The player doesn't need to be connected for this to work.
+	return PawnManager::Get()->players->getDefaultColour(pid).RGBA();
+}
+
 SCRIPT_API(GetPlayerDrunkLevel, int(IPlayer& player))
 {
 	return player.getDrunkLevel();
@@ -290,6 +296,11 @@ SCRIPT_API(TogglePlayerClock, bool(IPlayer& player, bool enable))
 {
 	player.useClock(enable);
 	return true;
+}
+
+SCRIPT_API(PlayerHasClockEnabled, bool(IPlayer& player))
+{
+	return player.hasClock();
 }
 
 SCRIPT_API(ForceClassSelection, bool(IPlayer& player))
@@ -497,7 +508,7 @@ SCRIPT_API(GetPlayerBuildingsRemoved, int(IPlayer& player))
 SCRIPT_API(RemovePlayerFromVehicle, bool(IPlayer& player))
 {
 	cell* args = GetParams();
-	player.removeFromVehicle(args[0] == 8 && args[2]);
+	player.removeFromVehicle(args[0] == 2 * sizeof(cell) && args[2]);
 	return true;
 }
 

--- a/Server/Components/Pawn/Scripting/Vehicle/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Vehicle/Natives.cpp
@@ -10,6 +10,7 @@
 #include <Server/Components/Vehicles/vehicle_components.hpp>
 #include <Server/Components/Vehicles/vehicle_models.hpp>
 #include <Server/Components/Vehicles/vehicle_colours.hpp>
+#include <Server/Components/Vehicles/vehicle_seats.hpp>
 #include <sdk.hpp>
 
 SCRIPT_API(CreateVehicle, int(int modelid, Vector3 pos, float rotation, int colour1, int colour2, int respawnDelay))
@@ -31,6 +32,11 @@ SCRIPT_API(CreateVehicle, int(int modelid, Vector3 pos, float rotation, int colo
 		}
 	}
 	return INVALID_VEHICLE_ID;
+}
+
+SCRIPT_API(GetVehicleSeats, int(int modelid))
+{
+	return Impl::getVehiclePassengerSeats(modelid);
 }
 
 SCRIPT_API(DestroyVehicle, bool(IVehicle& vehicle))
@@ -265,9 +271,14 @@ SCRIPT_API(GetVehicleComponentInSlot, int(IVehicle& vehicle, int slot))
 	return vehicle.getComponentInSlot(slot);
 }
 
-SCRIPT_API(GetVehicleComponentType, int(int component))
+SCRIPT_API(GetVehicleComponentType, int(int componentid))
 {
-	return getVehicleComponentSlot(component);
+	return getVehicleComponentSlot(componentid);
+}
+
+SCRIPT_API(VehicleCanHaveComponent, bool(int modelid, int componentid))
+{
+	return Impl::isValidComponentForVehicleModel(modelid, componentid);
 }
 
 SCRIPT_API(GetRandomCarColPair, void(int modelid, int& colour1, int& colour2, int& colour3, int& colour4))

--- a/Server/Source/player_pool.hpp
+++ b/Server/Source/player_pool.hpp
@@ -1192,11 +1192,9 @@ struct PlayerPool final : public IPlayerPool, public NetworkEventHandler, public
 		}
 	} playerWeaponsUpdateHandler;
 
-	void initPlayer(Player& player)
+	Colour getDefaultColour(int pid) const override
 	{
-		player.streamedFor_.add(player.poolID, player);
-
-		// Predefined set of colours. (https://github.com/Open-GTO/sa-mp-fixes/blob/master/fixes.inc#L3846)
+		// Predefined set of colours. (https://github.com/Open-GTO/sa-mp-fixes/blob/master/fixes.inc#L3846
 		static constexpr uint32_t colours[] = {
 			0xFF8C13FF,
 			0xC715FFFF,
@@ -1299,7 +1297,13 @@ struct PlayerPool final : public IPlayerPool, public NetworkEventHandler, public
 			0xD8C762FF,
 			0xD8C762FF,
 		};
-		player.colour_ = Colour::FromRGBA(colours[player.poolID % GLM_COUNTOF(colours)]);
+		return Colour::FromRGBA(colours[pid % GLM_COUNTOF(colours)]);
+	}
+
+	void initPlayer(Player& player)
+	{
+		player.streamedFor_.add(player.poolID, player);
+		player.colour_ = getDefaultColour(player.poolID);
 	}
 
 	struct PlayerPassengerSyncHandler : public SingleNetworkInEventHandler


### PR DESCRIPTION
Most of these were trivial as the data already existed in the server:

* `GetDefaultPlayerColour` - just a wrapper for a newly abstracted `PlayerPool::getDefaultColour` function.
* `GetVehicleSeats` - wraps `getVehiclePassengerSeats`.
* `VehicleCanHaveComponent` - wraps `isValidComponentForVehicleModel`.
* `IsValidAnimationLibrary` - wraps `animationLibraryValid`, including an optional second parameter (default `true`).
* `PlayerHasClockEnabled` - wraps `player.hasClock`.

Although the server also missed `IsMenuValid` it has `IsValidMenu` instead, though that doesn't fix the syntax pattern on the other `IsMenuXXX` functions.  I'll leave this fix to includes for now, we can maybe think about updating the server later.