### PR TITLE
Fixed behavior difference in SetPlayerName():

### DIFF
--- a/SDK/include/player.hpp
+++ b/SDK/include/player.hpp
@@ -444,8 +444,7 @@ struct IPlayer;
 enum EPlayerNameStatus
 {
 	Updated, ///< The name has successfully been updated
-	TakenByAnotherPlayer, ///< The name is already taken by another player
-	Taken, ///< The name is already taken by player
+	Taken, ///< The name is already taken by player (or another player)
 	Invalid ///< The name is invalid
 };
 

--- a/SDK/include/player.hpp
+++ b/SDK/include/player.hpp
@@ -444,7 +444,8 @@ struct IPlayer;
 enum EPlayerNameStatus
 {
 	Updated, ///< The name has successfully been updated
-	Taken, ///< The name is already taken by another player
+	TakenByAnotherPlayer, ///< The name is already taken by another player
+	Taken, ///< The name is already taken by player
 	Invalid ///< The name is invalid
 };
 

--- a/SDK/include/utils.hpp
+++ b/SDK/include/utils.hpp
@@ -19,7 +19,7 @@ inline StringView trim(StringView view)
 }
 
 /// Makes Case Insensitive comparison of StringView strings
-inline bool strIsEqualCI(const StringView& str1, const StringView& str2)
+inline bool strIsEqualCI(const StringView str1, const StringView str2)
 {
 	return std::equal(str1.begin(), str1.end(), str2.begin(), str2.end(),
 		[](const char& c1, const char& c2)

--- a/SDK/include/utils.hpp
+++ b/SDK/include/utils.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "types.hpp"
+#include <cctype>
+
 #define STRINGIFY(s) _STRINGIFY(s)
 #define _STRINGIFY(s) #s
 
@@ -13,4 +16,14 @@ inline StringView trim(StringView view)
 	}
 	const size_t end = view.find_last_not_of(whitespace);
 	return view.substr(start, end - start + 1);
+}
+
+//Makes Case Insensitive comparison for StringView strings
+inline bool strIsEqualCI(const StringView& str1, const StringView& str2)
+{
+	return std::equal(str1.begin(), str1.end(), str2.begin(), str2.end(),
+		[](const char& c1, const char& c2)
+		{
+			return std::tolower(c1) == std::tolower(c2);
+		});
 }

--- a/SDK/include/utils.hpp
+++ b/SDK/include/utils.hpp
@@ -18,7 +18,7 @@ inline StringView trim(StringView view)
 	return view.substr(start, end - start + 1);
 }
 
-//Makes Case Insensitive comparison for StringView strings
+/// Makes Case Insensitive comparison of StringView strings
 inline bool strIsEqualCI(const StringView& str1, const StringView& str2)
 {
 	return std::equal(str1.begin(), str1.end(), str2.begin(), str2.end(),

--- a/Server/Components/Pawn/Scripting/Player/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Player/Natives.cpp
@@ -253,8 +253,22 @@ SCRIPT_API(ResetPlayerMoney, bool(IPlayer& player))
 
 SCRIPT_API(SetPlayerName, int(IPlayer& player, const std::string& name))
 {
+	int result = -1;
 	EPlayerNameStatus status = player.setName(name);
-	return status == EPlayerNameStatus::Updated ? 1 : (status == EPlayerNameStatus::Invalid ? -1 : 0);
+	
+	switch (status)
+	{
+	case EPlayerNameStatus::Updated:
+		result = 1;
+		break;
+	case EPlayerNameStatus::Taken:
+		result = 0;
+		break;
+	default:
+		result = -1;
+		break;
+	}
+	return result;
 }
 
 SCRIPT_API(GetPlayerName, int(IPlayer& player, OutputOnlyString& name))

--- a/Server/Components/Pawn/Scripting/Player/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Player/Natives.cpp
@@ -255,7 +255,6 @@ SCRIPT_API(SetPlayerName, int(IPlayer& player, const std::string& name))
 {
 	int result = -1;
 	EPlayerNameStatus status = player.setName(name);
-	
 	switch (status)
 	{
 	case EPlayerNameStatus::Updated:

--- a/Server/Source/player.cpp
+++ b/Server/Source/player.cpp
@@ -8,6 +8,7 @@
 
 #include "player_pool.hpp"
 #include <Impl/network_impl.hpp>
+#include <utils.hpp>
 
 void Player::setColour(Colour colour)
 {
@@ -35,9 +36,13 @@ EPlayerNameStatus Player::setName(StringView name)
 	{
 		return EPlayerNameStatus::Invalid;
 	}
-	if (pool_.isNameTaken(name, this))
+	if (strIsEqualCI(name_, name))
 	{
 		return EPlayerNameStatus::Taken;
+	}
+	if (pool_.isNameTaken(name, this))
+	{
+		return EPlayerNameStatus::TakenByAnotherPlayer;
 	}
 
 	const auto oldName = name_;

--- a/Server/Source/player.cpp
+++ b/Server/Source/player.cpp
@@ -36,13 +36,9 @@ EPlayerNameStatus Player::setName(StringView name)
 	{
 		return EPlayerNameStatus::Invalid;
 	}
-	if (strIsEqualCI(name_, name))
+	if (pool_.isNameTaken(name, nullptr))
 	{
 		return EPlayerNameStatus::Taken;
-	}
-	if (pool_.isNameTaken(name, this))
-	{
-		return EPlayerNameStatus::TakenByAnotherPlayer;
 	}
 
 	const auto oldName = name_;

--- a/Server/Source/player_pool.hpp
+++ b/Server/Source/player_pool.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils.hpp"
 #include "player_impl.hpp"
 #include <Server/Components/Console/console.hpp>
 
@@ -1858,12 +1859,7 @@ struct PlayerPool final : public IPlayerPool, public NetworkEventHandler, public
 				{
 					return false;
 				}
-				StringView otherName = player->getName();
-				return std::equal(name.begin(), name.end(), otherName.begin(), otherName.end(),
-					[](const char& c1, const char& c2)
-					{
-						return std::tolower(c1) == std::tolower(c2);
-					});
+				return strIsEqualCI(name, player->getName());
 			});
 	}
 


### PR DESCRIPTION
If the specified name has already been taken by player - it is set anyway, then native returns 1. (should 0 and the same name cannot be re-set). 
If name has already been taken by another player, native returns 0 (should -1).

[Docs](https://www.open.mp/docs/scripting/functions/SetPlayerName)