### PR TITLE
Fix HTTP calls and AnnounceHTTPResponseHandler 

### DIFF
--- a/Server/Components/LegacyNetwork/legacy_network_impl.hpp
+++ b/Server/Components/LegacyNetwork/legacy_network_impl.hpp
@@ -394,7 +394,14 @@ struct AnnounceHTTPResponseHandler final : HTTPResponseHandler
 	{
 		if (status != 200)
 		{
-			core->printLn("Failed to announce legacy network to open.mp list");
+			if (status < 100)
+			{
+				core->printLn("Failed to announce legacy network to open.mp list.\n\t[HTTP Client Error] Status: %d", status);
+			}
+			else
+			{
+				core->printLn("Failed to announce legacy network to open.mp list.\n\t[Server Error] Status: %d\n\t[Server Error] Message: %.*s", status, PRINT_VIEW(body));
+			}
 		}
 		delete this;
 	}

--- a/Server/Source/core_impl.hpp
+++ b/Server/Source/core_impl.hpp
@@ -843,8 +843,9 @@ private:
 		request.enable_server_certificate_verification(true);
 		request.set_follow_location(true);
 		request.set_connection_timeout(Seconds(5));
-		request.set_read_timeout(Seconds(5));
+		request.set_read_timeout(Seconds(60));
 		request.set_write_timeout(Seconds(5));
+		request.set_keep_alive(true);
 
 		// Run request
 		httplib::Result res(nullptr, httplib::Error::Canceled);


### PR DESCRIPTION
Fixes #616 and also all HTTP requests generally, by increasing read timeout, allowing the engine to wait for response first before going through the process of reading it (5 seconds was not enough)