### PR TITLE
Some proper pawn native param casts

### DIFF
--- a/SDK/include/Server/Components/GangZones/gangzones.hpp
+++ b/SDK/include/Server/Components/GangZones/gangzones.hpp
@@ -13,7 +13,7 @@ struct GangZonePos
 };
 
 /// Gangzone interace
-struct IGangZone : public IExtensible, public IIDProvider
+struct IBaseGangZone : public IExtensible, public IIDProvider
 {
 	/// Check if a gangzone is shown for player
 	virtual bool isShownForPlayer(const IPlayer& player) const = 0;
@@ -56,6 +56,14 @@ struct IGangZone : public IExtensible, public IIDProvider
 
 	/// Used by legacy per-player gangzones for ID mapping.
 	virtual IPlayer* getLegacyPlayer() const = 0;
+};
+
+struct IGangZone : public IBaseGangZone
+{
+};
+
+struct IPlayerGangZone : public IBaseGangZone
+{
 };
 
 struct GangZoneEventHandler

--- a/SDK/include/Server/Components/Pawn/pawn_natives.hpp
+++ b/SDK/include/Server/Components/Pawn/pawn_natives.hpp
@@ -520,6 +520,7 @@ PLAYER_POOL_PARAM(IPlayerTextDraw, IPlayerTextDrawData);
 PLAYER_POOL_PARAM(IPlayerTextLabel, IPlayerTextLabelData);
 
 PLAYER_DATA_PARAM(IPlayerVehicleData);
+PLAYER_DATA_PARAM(IPlayerCheckpointData);
 
 GLOBAL_MIXED_POOL_PARAM(IPickup, pickups);
 PLAYER_MIXED_POOL_PARAM(IPlayerPickup, IPlayerPickupData, pickups);

--- a/SDK/include/Server/Components/Pawn/pawn_natives.hpp
+++ b/SDK/include/Server/Components/Pawn/pawn_natives.hpp
@@ -521,6 +521,10 @@ PLAYER_POOL_PARAM(IPlayerTextLabel, IPlayerTextLabelData);
 
 PLAYER_DATA_PARAM(IPlayerVehicleData);
 PLAYER_DATA_PARAM(IPlayerCheckpointData);
+PLAYER_DATA_PARAM(IPlayerObjectData);
+PLAYER_DATA_PARAM(IPlayerTextDrawData);
+PLAYER_DATA_PARAM(IPlayerConsoleData);
+PLAYER_DATA_PARAM(IPlayerDialogData);
 
 GLOBAL_MIXED_POOL_PARAM(IPickup, pickups);
 PLAYER_MIXED_POOL_PARAM(IPlayerPickup, IPlayerPickupData, pickups);

--- a/SDK/include/Server/Components/Pawn/pawn_natives.hpp
+++ b/SDK/include/Server/Components/Pawn/pawn_natives.hpp
@@ -308,15 +308,209 @@ using OutputOnlyString = std::variant<bool, StringView, Impl::String>;
 		ParamCast() = delete;                                                              \
 	};
 
+/// Macro to define a script param for a mixed pool's global entry
+#define GLOBAL_MIXED_POOL_PARAM(type, poolPtr)                 \
+	template <>                                                \
+	struct ParamLookup<type>                                   \
+	{                                                          \
+		static type& ValReq(cell ref)                          \
+		{                                                      \
+			auto pool = getAmxLookups()->poolPtr;              \
+			if (pool)                                          \
+			{                                                  \
+				auto ptr = pool->get(pool->fromLegacyID(ref)); \
+				if (ptr)                                       \
+				{                                              \
+					return *ptr;                               \
+				}                                              \
+			}                                                  \
+			throw pawn_natives::ParamCastFailure();            \
+		}                                                      \
+                                                               \
+		static type* Val(cell ref) noexcept                    \
+		{                                                      \
+			auto pool = getAmxLookups()->poolPtr;              \
+			if (pool)                                          \
+			{                                                  \
+				return pool->get(pool->fromLegacyID(ref));     \
+			}                                                  \
+			return nullptr;                                    \
+		}                                                      \
+	};                                                         \
+                                                               \
+	template <>                                                \
+	class ParamCast<type*>                                     \
+	{                                                          \
+	public:                                                    \
+		ParamCast(AMX* amx, cell* params, int idx) noexcept    \
+		{                                                      \
+			value_ = ParamLookup<type>::Val(params[idx]);      \
+		}                                                      \
+                                                               \
+		~ParamCast()                                           \
+		{                                                      \
+		}                                                      \
+                                                               \
+		ParamCast(ParamCast<type*> const&) = delete;           \
+		ParamCast(ParamCast<type*>&&) = delete;                \
+                                                               \
+		operator type*()                                       \
+		{                                                      \
+			return value_;                                     \
+		}                                                      \
+                                                               \
+		static constexpr int Size = 1;                         \
+                                                               \
+	private:                                                   \
+		type* value_;                                          \
+	};                                                         \
+                                                               \
+	template <>                                                \
+	class ParamCast<type&>                                     \
+	{                                                          \
+	public:                                                    \
+		ParamCast(AMX* amx, cell* params, int idx)             \
+			: value_(ParamLookup<type>::ValReq(params[idx]))   \
+		{                                                      \
+		}                                                      \
+                                                               \
+		~ParamCast()                                           \
+		{                                                      \
+		}                                                      \
+                                                               \
+		ParamCast(ParamCast<type&> const&) = delete;           \
+		ParamCast(ParamCast<type&>&&) = delete;                \
+                                                               \
+		operator type&()                                       \
+		{                                                      \
+			return value_;                                     \
+		}                                                      \
+                                                               \
+		static constexpr int Size = 1;                         \
+                                                               \
+	private:                                                   \
+		type& value_;                                          \
+	};                                                         \
+                                                               \
+	template <>                                                \
+	class ParamCast<const type&>                               \
+	{                                                          \
+	public:                                                    \
+		ParamCast(AMX*, cell*, int) = delete;                  \
+		ParamCast() = delete;                                  \
+	};
+
+/// Macro to define a script param for a mixed pool's player entry
+#define PLAYER_MIXED_POOL_PARAM(type, dataType, poolPtr)                                                                                   \
+	template <>                                                                                                                            \
+	struct ParamLookup<type>                                                                                                               \
+	{                                                                                                                                      \
+		static type& ValReq(IPlayer& player, cell ref)                                                                                     \
+		{                                                                                                                                  \
+			auto data = queryExtension<dataType>(player);                                                                                  \
+			auto pool = getAmxLookups()->poolPtr;                                                                                          \
+			if (pool && data)                                                                                                              \
+			{                                                                                                                              \
+				auto ptr = pool->get(data->fromLegacyID(ref));                                                                             \
+				if (ptr)                                                                                                                   \
+				{                                                                                                                          \
+					return *reinterpret_cast<type*>(ptr);                                                                                  \
+				}                                                                                                                          \
+			}                                                                                                                              \
+			throw pawn_natives::ParamCastFailure();                                                                                        \
+		}                                                                                                                                  \
+                                                                                                                                           \
+		static type* Val(IPlayer& player, cell ref) noexcept                                                                               \
+		{                                                                                                                                  \
+			auto data = queryExtension<dataType>(player);                                                                                  \
+			auto pool = getAmxLookups()->poolPtr;                                                                                          \
+			if (pool && data)                                                                                                              \
+			{                                                                                                                              \
+				return reinterpret_cast<type*>(pool->get(data->fromLegacyID(ref)));                                                        \
+			}                                                                                                                              \
+			return nullptr;                                                                                                                \
+		}                                                                                                                                  \
+	};                                                                                                                                     \
+                                                                                                                                           \
+	template <>                                                                                                                            \
+	class ParamCast<type*>                                                                                                                 \
+	{                                                                                                                                      \
+	public:                                                                                                                                \
+		ParamCast(AMX* amx, cell* params, int idx)                                                                                         \
+		{                                                                                                                                  \
+			value_ = ParamLookup<type>::Val(ParamLookup<IPlayer>::ValReq(params[1] /* first param is always playerid */), params[idx]);    \
+		}                                                                                                                                  \
+                                                                                                                                           \
+		~ParamCast()                                                                                                                       \
+		{                                                                                                                                  \
+		}                                                                                                                                  \
+                                                                                                                                           \
+		ParamCast(ParamCast<type*> const&) = delete;                                                                                       \
+		ParamCast(ParamCast<type*>&&) = delete;                                                                                            \
+                                                                                                                                           \
+		operator type*()                                                                                                                   \
+		{                                                                                                                                  \
+			return value_;                                                                                                                 \
+		}                                                                                                                                  \
+                                                                                                                                           \
+		static constexpr int Size = 1;                                                                                                     \
+                                                                                                                                           \
+	private:                                                                                                                               \
+		type* value_;                                                                                                                      \
+	};                                                                                                                                     \
+                                                                                                                                           \
+	template <>                                                                                                                            \
+	class ParamCast<type const*>                                                                                                           \
+	{                                                                                                                                      \
+	public:                                                                                                                                \
+		ParamCast(AMX* amx, cell* params, int idx) = delete;                                                                               \
+		ParamCast() = delete;                                                                                                              \
+	};                                                                                                                                     \
+                                                                                                                                           \
+	template <>                                                                                                                            \
+	class ParamCast<type&>                                                                                                                 \
+	{                                                                                                                                      \
+	public:                                                                                                                                \
+		ParamCast(AMX* amx, cell* params, int idx)                                                                                         \
+			: value_(ParamLookup<type>::ValReq(ParamLookup<IPlayer>::ValReq(params[1] /* first param is always playerid */), params[idx])) \
+		{                                                                                                                                  \
+		}                                                                                                                                  \
+                                                                                                                                           \
+		~ParamCast()                                                                                                                       \
+		{                                                                                                                                  \
+		}                                                                                                                                  \
+                                                                                                                                           \
+		ParamCast(ParamCast<type&> const&) = delete;                                                                                       \
+		ParamCast(ParamCast<type&>&&) = delete;                                                                                            \
+                                                                                                                                           \
+		operator type&()                                                                                                                   \
+		{                                                                                                                                  \
+			return value_;                                                                                                                 \
+		}                                                                                                                                  \
+                                                                                                                                           \
+		static constexpr int Size = 1;                                                                                                     \
+                                                                                                                                           \
+	private:                                                                                                                               \
+		type& value_;                                                                                                                      \
+	};                                                                                                                                     \
+                                                                                                                                           \
+	template <>                                                                                                                            \
+	class ParamCast<const type&>                                                                                                           \
+	{                                                                                                                                      \
+	public:                                                                                                                                \
+		ParamCast(AMX*, cell*, int) = delete;                                                                                              \
+		ParamCast() = delete;                                                                                                              \
+	};
+
 // custom ParamCasts here to use custom types in native declarations
 namespace pawn_natives
 {
+
 POOL_PARAM(IPlayer, players);
 POOL_PARAM(IActor, actors);
 POOL_PARAM(IClass, classes);
 POOL_PARAM(IMenu, menus);
 POOL_PARAM(IObject, objects);
-POOL_PARAM(IPickup, pickups);
 POOL_PARAM(ITextDraw, textdraws);
 POOL_PARAM(ITextLabel, textlabels);
 POOL_PARAM(IVehicle, vehicles);
@@ -326,6 +520,9 @@ PLAYER_POOL_PARAM(IPlayerTextDraw, IPlayerTextDrawData);
 PLAYER_POOL_PARAM(IPlayerTextLabel, IPlayerTextLabelData);
 
 PLAYER_DATA_PARAM(IPlayerVehicleData);
+
+GLOBAL_MIXED_POOL_PARAM(IPickup, pickups);
+PLAYER_MIXED_POOL_PARAM(IPlayerPickup, IPlayerPickupData, pickups);
 
 /// A parameter used for only writing data to an output string
 /// Greatly speeds up code as there's no need for reading the input string

--- a/SDK/include/Server/Components/Pawn/pawn_natives.hpp
+++ b/SDK/include/Server/Components/Pawn/pawn_natives.hpp
@@ -523,6 +523,8 @@ PLAYER_DATA_PARAM(IPlayerVehicleData);
 
 GLOBAL_MIXED_POOL_PARAM(IPickup, pickups);
 PLAYER_MIXED_POOL_PARAM(IPlayerPickup, IPlayerPickupData, pickups);
+GLOBAL_MIXED_POOL_PARAM(IGangZone, gangzones);
+PLAYER_MIXED_POOL_PARAM(IPlayerGangZone, IPlayerGangZoneData, gangzones);
 
 /// A parameter used for only writing data to an output string
 /// Greatly speeds up code as there's no need for reading the input string

--- a/SDK/include/Server/Components/Pickups/pickups.hpp
+++ b/SDK/include/Server/Components/Pickups/pickups.hpp
@@ -7,8 +7,8 @@
 
 typedef uint8_t PickupType;
 
-/// Pickup interace
-struct IPickup : public IExtensible, public IEntity
+/// Pickup base interface
+struct IBasePickup : public IExtensible, public IEntity
 {
 	/// Sets pickup's type and restreams
 	virtual void setType(PickupType type, bool update = true) = 0;
@@ -45,6 +45,14 @@ struct IPickup : public IExtensible, public IEntity
 
 	/// Used by legacy per-player pickups for ID mapping.
 	virtual IPlayer* getLegacyPlayer() const = 0;
+};
+
+struct IPickup : public IBasePickup
+{
+};
+
+struct IPlayerPickup : public IBasePickup
+{
 };
 
 struct PickupEventHandler

--- a/Server/Components/Pawn/Scripting/Checkpoint/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Checkpoint/Natives.cpp
@@ -11,134 +11,87 @@
 #include "sdk.hpp"
 #include <iostream>
 
-SCRIPT_API(SetPlayerCheckpoint, bool(IPlayer& player, Vector3 centrePosition, float radius))
+SCRIPT_API(SetPlayerCheckpoint, bool(IPlayerCheckpointData& data, Vector3 centrePosition, float radius))
 {
-	IPlayerCheckpointData* playerCheckpointData = queryExtension<IPlayerCheckpointData>(player);
-	if (playerCheckpointData)
+	ICheckpointData& cp = data.getCheckpoint();
+	cp.setPosition(centrePosition);
+	cp.setRadius(radius); // samp native receives radius not diameter
+	cp.enable();
+	return true;
+}
+
+SCRIPT_API(DisablePlayerCheckpoint, bool(IPlayerCheckpointData& data))
+{
+	ICheckpointData& cp = data.getCheckpoint();
+	cp.disable();
+	return true;
+}
+
+SCRIPT_API(IsPlayerInCheckpoint, bool(IPlayerCheckpointData& data))
+{
+	ICheckpointData& cp = data.getCheckpoint();
+	if (cp.isEnabled())
 	{
-		ICheckpointData& cp = playerCheckpointData->getCheckpoint();
+		return cp.isPlayerInside();
+	}
+	return false;
+}
+
+SCRIPT_API(SetPlayerRaceCheckpoint, bool(IPlayerCheckpointData& data, int type, Vector3 centrePosition, Vector3 nextPosition, float radius))
+{
+	IRaceCheckpointData& cp = data.getRaceCheckpoint();
+	if (type >= 0 && type <= 8)
+	{
+		cp.setType(RaceCheckpointType(type));
 		cp.setPosition(centrePosition);
-		cp.setRadius(radius); // samp native receives radius not diameter
+		cp.setNextPosition(nextPosition);
+		cp.setRadius(radius); // samp native receives radius unlike standard checkpoints
 		cp.enable();
 		return true;
 	}
 	return false;
 }
 
-SCRIPT_API(DisablePlayerCheckpoint, bool(IPlayer& player))
+SCRIPT_API(DisablePlayerRaceCheckpoint, bool(IPlayerCheckpointData& data))
 {
-	IPlayerCheckpointData* playerCheckpointData = queryExtension<IPlayerCheckpointData>(player);
-	if (playerCheckpointData)
+	IRaceCheckpointData& cp = data.getRaceCheckpoint();
+	cp.disable();
+	return true;
+}
+
+SCRIPT_API(IsPlayerInRaceCheckpoint, bool(IPlayerCheckpointData& data))
+{
+	IRaceCheckpointData& cp = data.getRaceCheckpoint();
+	if (cp.getType() != RaceCheckpointType::RACE_NONE && cp.isEnabled())
 	{
-		ICheckpointData& cp = playerCheckpointData->getCheckpoint();
-		cp.disable();
-		return true;
+		return cp.isPlayerInside();
 	}
 	return false;
 }
 
-SCRIPT_API(IsPlayerInCheckpoint, bool(IPlayer& player))
+SCRIPT_API(IsPlayerCheckpointActive, bool(IPlayerCheckpointData& data))
 {
-	IPlayerCheckpointData* playerCheckpointData = queryExtension<IPlayerCheckpointData>(player);
-	if (playerCheckpointData)
-	{
-		ICheckpointData& cp = playerCheckpointData->getCheckpoint();
-		if (cp.isEnabled())
-		{
-			return cp.isPlayerInside();
-		}
-	}
-	return false;
+	return data.getCheckpoint().isEnabled();
 }
 
-SCRIPT_API(SetPlayerRaceCheckpoint, bool(IPlayer& player, int type, Vector3 centrePosition, Vector3 nextPosition, float radius))
+SCRIPT_API(GetPlayerCheckpoint, bool(IPlayerCheckpointData& data, Vector3& centrePosition, float& radius))
 {
-	IPlayerCheckpointData* playerCheckpointData = queryExtension<IPlayerCheckpointData>(player);
-	if (playerCheckpointData)
-	{
-		IRaceCheckpointData& cp = playerCheckpointData->getRaceCheckpoint();
-		if (type >= 0 && type <= 8)
-		{
-			cp.setType(RaceCheckpointType(type));
-			cp.setPosition(centrePosition);
-			cp.setNextPosition(nextPosition);
-			cp.setRadius(radius); // samp native receives radius unlike standard checkpoints
-			cp.enable();
-			return true;
-		}
-	}
-	return false;
+	const ICheckpointData& cp = data.getCheckpoint();
+	centrePosition = cp.getPosition();
+	radius = cp.getRadius();
+	return true;
 }
 
-SCRIPT_API(DisablePlayerRaceCheckpoint, bool(IPlayer& player))
+SCRIPT_API(IsPlayerRaceCheckpointActive, bool(IPlayerCheckpointData& data))
 {
-	IPlayerCheckpointData* playerCheckpointData = queryExtension<IPlayerCheckpointData>(player);
-	if (playerCheckpointData)
-	{
-		IRaceCheckpointData& cp = playerCheckpointData->getRaceCheckpoint();
-		cp.disable();
-		return true;
-	}
-	return false;
+	return data.getRaceCheckpoint().isEnabled();
 }
 
-SCRIPT_API(IsPlayerInRaceCheckpoint, bool(IPlayer& player))
+SCRIPT_API(GetPlayerRaceCheckpoint, bool(IPlayerCheckpointData& data, Vector3& centrePosition, Vector3& nextPosition, float& radius))
 {
-	IPlayerCheckpointData* playerCheckpointData = queryExtension<IPlayerCheckpointData>(player);
-	if (playerCheckpointData)
-	{
-		IRaceCheckpointData& cp = playerCheckpointData->getRaceCheckpoint();
-		if (cp.getType() != RaceCheckpointType::RACE_NONE && cp.isEnabled())
-		{
-			return cp.isPlayerInside();
-		}
-	}
-	return false;
-}
-
-SCRIPT_API(IsPlayerCheckpointActive, bool(IPlayer& player))
-{
-	IPlayerCheckpointData* playerData = queryExtension<IPlayerCheckpointData>(player);
-	if (playerData)
-	{
-		return playerData->getCheckpoint().isEnabled();
-	}
-	return false;
-}
-
-SCRIPT_API(GetPlayerCheckpoint, bool(IPlayer& player, Vector3& centrePosition, float& radius))
-{
-	IPlayerCheckpointData* playerData = queryExtension<IPlayerCheckpointData>(player);
-	if (playerData)
-	{
-		const ICheckpointData& data = playerData->getCheckpoint();
-		centrePosition = data.getPosition();
-		radius = data.getRadius();
-		return true;
-	}
-	return false;
-}
-
-SCRIPT_API(IsPlayerRaceCheckpointActive, bool(IPlayer& player))
-{
-	IPlayerCheckpointData* playerData = queryExtension<IPlayerCheckpointData>(player);
-	if (playerData)
-	{
-		return playerData->getRaceCheckpoint().isEnabled();
-	}
-	return false;
-}
-
-SCRIPT_API(GetPlayerRaceCheckpoint, bool(IPlayer& player, Vector3& centrePosition, Vector3& nextPosition, float& radius))
-{
-	IPlayerCheckpointData* playerData = queryExtension<IPlayerCheckpointData>(player);
-	if (playerData)
-	{
-		const IRaceCheckpointData& data = playerData->getRaceCheckpoint();
-		centrePosition = data.getPosition();
-		nextPosition = data.getNextPosition();
-		radius = data.getRadius();
-		return true;
-	}
-	return false;
+	const IRaceCheckpointData& cp = data.getRaceCheckpoint();
+	centrePosition = cp.getPosition();
+	nextPosition = cp.getNextPosition();
+	radius = cp.getRadius();
+	return true;
 }

--- a/Server/Components/Pawn/Scripting/Dialog/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Dialog/Natives.cpp
@@ -48,46 +48,31 @@ SCRIPT_API(ShowPlayerDialog, bool(IPlayer& player, int dialog, int style, const 
 /// clarity.
 ///
 /// TODO: Add a deprecation warning to this native.
-SCRIPT_API_FAILRET(GetPlayerDialog, INVALID_DIALOG_ID, int(IPlayer& player))
+SCRIPT_API_FAILRET(GetPlayerDialog, INVALID_DIALOG_ID, int(IPlayerDialogData& data))
 {
-	IPlayerDialogData* dialog = queryExtension<IPlayerDialogData>(player);
-	if (dialog)
-	{
-		return dialog->getActiveID();
-	}
-	return INVALID_DIALOG_ID;
+	return data.getActiveID();
 }
 
-SCRIPT_API_FAILRET(GetPlayerDialogID, INVALID_DIALOG_ID, int(IPlayer& player))
+SCRIPT_API_FAILRET(GetPlayerDialogID, INVALID_DIALOG_ID, int(IPlayerDialogData& data))
 {
-	IPlayerDialogData* data = queryExtension<IPlayerDialogData>(player);
-	if (data)
-	{
-		return data->getActiveID();
-	}
-	return INVALID_DIALOG_ID;
+	return data.getActiveID();
 }
 
-SCRIPT_API(GetPlayerDialogData, bool(IPlayer& player, int& style, OutputOnlyString& title, OutputOnlyString& body, OutputOnlyString& button1, OutputOnlyString& button2))
+SCRIPT_API(GetPlayerDialogData, bool(IPlayerDialogData& data, int& style, OutputOnlyString& title, OutputOnlyString& body, OutputOnlyString& button1, OutputOnlyString& button2))
 {
-	IPlayerDialogData* dialog = queryExtension<IPlayerDialogData>(player);
-	if (dialog)
-	{
-		DialogStyle styleVar {};
-		StringView titleVar {};
-		StringView bodyVar {};
-		StringView button1Var {};
-		StringView button2Var {};
-		int dialogid;
-		dialog->get(dialogid, styleVar, titleVar, bodyVar, button1Var, button2Var);
-		style = int(styleVar);
-		title = titleVar;
-		body = bodyVar;
-		button1 = button1Var;
-		button2 = button2Var;
-		return dialogid != INVALID_DIALOG_ID;
-	}
-	return false;
+	DialogStyle styleVar {};
+	StringView titleVar {};
+	StringView bodyVar {};
+	StringView button1Var {};
+	StringView button2Var {};
+	int dialogid;
+	data.get(dialogid, styleVar, titleVar, bodyVar, button1Var, button2Var);
+	style = int(styleVar);
+	title = titleVar;
+	body = bodyVar;
+	button1 = button1Var;
+	button2 = button2Var;
+	return dialogid != INVALID_DIALOG_ID;
 }
 
 SCRIPT_API(HidePlayerDialog, bool(IPlayer& player))

--- a/Server/Components/Pawn/Scripting/GangZone/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/GangZone/Natives.cpp
@@ -10,16 +10,6 @@
 #include "sdk.hpp"
 #include <iostream>
 
-static IGangZone* TryGetGangZone(cell ref) noexcept
-{
-	auto pool = PawnManager::Get()->gangzones;
-	if (pool)
-	{
-		return pool->get(pool->fromLegacyID(ref));
-	}
-	return nullptr;
-}
-
 SCRIPT_API(GangZoneCreate, int(Vector2 min, Vector2 max))
 {
 	IGangZonesComponent* component = PawnManager::Get()->gangzones;
@@ -51,253 +41,156 @@ SCRIPT_API(GangZoneCreate, int(Vector2 min, Vector2 max))
 	return INVALID_GANG_ZONE_ID;
 }
 
-SCRIPT_API(GangZoneDestroy, bool(int legacyid))
+SCRIPT_API(GangZoneDestroy, bool(int gangzoneid))
 {
 	auto pool = PawnManager::Get()->gangzones;
 	if (pool)
 	{
-		int realid = pool->fromLegacyID(legacyid);
+		int realid = pool->fromLegacyID(gangzoneid);
 		if (realid)
 		{
 			pool->release(realid);
-			pool->releaseLegacyID(legacyid);
+			pool->releaseLegacyID(gangzoneid);
 			return true;
 		}
 	}
 	return false;
 }
 
-SCRIPT_API(GangZoneShowForPlayer, bool(IPlayer& player, cell gangzoneid, uint32_t colour))
+SCRIPT_API(GangZoneShowForPlayer, bool(IPlayer& player, IGangZone& gangzone, uint32_t colour))
 {
-	IGangZone* gangzone = TryGetGangZone(gangzoneid);
-	if (gangzone == nullptr)
-	{
-		return false;
-	}
-	gangzone->showForPlayer(player, Colour::FromRGBA(colour));
+	gangzone.showForPlayer(player, Colour::FromRGBA(colour));
 	return true;
 }
 
-SCRIPT_API(GangZoneShowForAll, bool(cell gangzoneid, uint32_t colour))
+SCRIPT_API(GangZoneShowForAll, bool(IGangZone& gangzone, uint32_t colour))
 {
-	IGangZone* gangzone = TryGetGangZone(gangzoneid);
-	if (gangzone == nullptr)
-	{
-		return false;
-	}
 	IPlayerPool* pool = PawnManager::Get()->players;
 	for (IPlayer* player : pool->entries())
 	{
-		gangzone->showForPlayer(*player, Colour::FromRGBA(colour));
+		gangzone.showForPlayer(*player, Colour::FromRGBA(colour));
 	}
 	return true;
 }
 
-SCRIPT_API(GangZoneHideForPlayer, bool(IPlayer& player, cell gangzoneid))
+SCRIPT_API(GangZoneHideForPlayer, bool(IPlayer& player, IGangZone& gangzone))
 {
-	IGangZone* gangzone = TryGetGangZone(gangzoneid);
-	if (gangzone == nullptr)
-	{
-		return false;
-	}
-	gangzone->hideForPlayer(player);
+	gangzone.hideForPlayer(player);
 	return true;
 }
 
-SCRIPT_API(GangZoneHideForAll, bool(cell gangzoneid))
+SCRIPT_API(GangZoneHideForAll, bool(IGangZone& gangzone))
 {
-	IGangZone* gangzone = TryGetGangZone(gangzoneid);
-	if (gangzone == nullptr)
-	{
-		return false;
-	}
 	IPlayerPool* pool = PawnManager::Get()->players;
 	for (IPlayer* player : pool->entries())
 	{
-		gangzone->hideForPlayer(*player);
+		gangzone.hideForPlayer(*player);
 	}
 	return true;
 }
 
-SCRIPT_API(GangZoneFlashForPlayer, bool(IPlayer& player, cell gangzoneid, uint32_t colour))
+SCRIPT_API(GangZoneFlashForPlayer, bool(IPlayer& player, IGangZone& gangzone, uint32_t colour))
 {
-	IGangZone* gangzone = TryGetGangZone(gangzoneid);
-	if (gangzone == nullptr)
-	{
-		return false;
-	}
-	gangzone->flashForPlayer(player, Colour::FromRGBA(colour));
+	gangzone.flashForPlayer(player, Colour::FromRGBA(colour));
 	return true;
 }
 
-SCRIPT_API(GangZoneFlashForAll, bool(cell gangzoneid, uint32_t colour))
+SCRIPT_API(GangZoneFlashForAll, bool(IGangZone& gangzone, uint32_t colour))
 {
-	IGangZone* gangzone = TryGetGangZone(gangzoneid);
-	if (gangzone == nullptr)
-	{
-		return false;
-	}
 	IPlayerPool* pool = PawnManager::Get()->players;
 	for (IPlayer* player : pool->entries())
 	{
-		gangzone->flashForPlayer(*player, Colour::FromRGBA(colour));
+		gangzone.flashForPlayer(*player, Colour::FromRGBA(colour));
 	}
 	return true;
 }
 
-SCRIPT_API(GangZoneStopFlashForPlayer, bool(IPlayer& player, cell gangzoneid))
+SCRIPT_API(GangZoneStopFlashForPlayer, bool(IPlayer& player, IGangZone& gangzone))
 {
-	IGangZone* gangzone = TryGetGangZone(gangzoneid);
-	if (gangzone == nullptr)
-	{
-		return false;
-	}
-	gangzone->stopFlashForPlayer(player);
+	gangzone.stopFlashForPlayer(player);
 	return true;
 }
 
-SCRIPT_API(GangZoneStopFlashForAll, bool(cell gangzoneid))
+SCRIPT_API(GangZoneStopFlashForAll, bool(IGangZone& gangzone))
 {
-	IGangZone* gangzone = TryGetGangZone(gangzoneid);
-	if (gangzone == nullptr)
-	{
-		return false;
-	}
 	IPlayerPool* pool = PawnManager::Get()->players;
 	for (IPlayer* player : pool->entries())
 	{
-		gangzone->stopFlashForPlayer(*player);
+		gangzone.stopFlashForPlayer(*player);
 	}
 	return true;
 }
 
-SCRIPT_API(IsValidGangZone, bool(cell gangzoneid))
+SCRIPT_API(IsValidGangZone, bool(IGangZone& gangzone))
 {
-	return TryGetGangZone(gangzoneid) != nullptr;
+	return true;
 }
 
-SCRIPT_API(IsPlayerInGangZone, bool(IPlayer& player, cell gangzoneid))
+SCRIPT_API(IsPlayerInGangZone, bool(IPlayer& player, IGangZone& gangzone))
 {
-	IGangZone* gangzone = TryGetGangZone(gangzoneid);
-	if (gangzone == nullptr)
-	{
-		return false;
-	}
-	return gangzone->isPlayerInside(player);
+	return gangzone.isPlayerInside(player);
 }
 
-SCRIPT_API(IsGangZoneVisibleForPlayer, bool(IPlayer& player, cell gangzoneid))
+SCRIPT_API(IsGangZoneVisibleForPlayer, bool(IPlayer& player, IGangZone& gangzone))
 {
-	IGangZone* gangzone = TryGetGangZone(gangzoneid);
-	if (gangzone == nullptr)
-	{
-		return false;
-	}
-	return gangzone->isShownForPlayer(player);
+	return gangzone.isShownForPlayer(player);
 }
 
-SCRIPT_API(GangZoneGetColorForPlayer, int(IPlayer& player, cell gangzoneid))
+SCRIPT_API(GangZoneGetColorForPlayer, int(IPlayer& player, IGangZone& gangzone))
 {
-	IGangZone* gangzone = TryGetGangZone(gangzoneid);
-	if (gangzone == nullptr)
+	if (gangzone.isShownForPlayer(player))
 	{
-		return 0;
+		return gangzone.getColourForPlayer(player).RGBA();
 	}
-	if (gangzone->isShownForPlayer(player))
-	{
-		return gangzone->getColourForPlayer(player).RGBA();
-	}
-	else
-	{
-		return 0;
-	}
+	return 0;
 }
 
-SCRIPT_API(GangZoneGetFlashColorForPlayer, int(IPlayer& player, cell gangzoneid))
+SCRIPT_API(GangZoneGetFlashColorForPlayer, int(IPlayer& player, IGangZone& gangzone))
 {
-	IGangZone* gangzone = TryGetGangZone(gangzoneid);
-	if (gangzone == nullptr)
+	if (gangzone.isShownForPlayer(player))
 	{
-		return 0;
+		return gangzone.getFlashingColourForPlayer(player).RGBA();
 	}
-	if (gangzone->isShownForPlayer(player))
-	{
-		return gangzone->getFlashingColourForPlayer(player).RGBA();
-	}
-	else
-	{
-		return 0;
-	}
+	return 0;
 }
 
-SCRIPT_API(GangZoneGetColourForPlayer, int(IPlayer& player, cell gangzoneid))
+SCRIPT_API(GangZoneGetColourForPlayer, int(IPlayer& player, IGangZone& gangzone))
 {
-	IGangZone* gangzone = TryGetGangZone(gangzoneid);
-	if (gangzone == nullptr)
+	if (gangzone.isShownForPlayer(player))
 	{
-		return 0;
+		return gangzone.getColourForPlayer(player).RGBA();
 	}
-	if (gangzone->isShownForPlayer(player))
-	{
-		return gangzone->getColourForPlayer(player).RGBA();
-	}
-	else
-	{
-		return 0;
-	}
+	return 0;
 }
 
-SCRIPT_API(GangZoneGetFlashColourForPlayer, int(IPlayer& player, cell gangzoneid))
+SCRIPT_API(GangZoneGetFlashColourForPlayer, int(IPlayer& player, IGangZone& gangzone))
 {
-	IGangZone* gangzone = TryGetGangZone(gangzoneid);
-	if (gangzone == nullptr)
+	if (gangzone.isShownForPlayer(player))
 	{
-		return 0;
+		return gangzone.getFlashingColourForPlayer(player).RGBA();
 	}
-	if (gangzone->isShownForPlayer(player))
-	{
-		return gangzone->getFlashingColourForPlayer(player).RGBA();
-	}
-	else
-	{
-		return 0;
-	}
+	return 0;
 }
 
-SCRIPT_API(IsGangZoneFlashingForPlayer, bool(IPlayer& player, cell gangzoneid))
+SCRIPT_API(IsGangZoneFlashingForPlayer, bool(IPlayer& player, IGangZone& gangzone))
 {
-	IGangZone* gangzone = TryGetGangZone(gangzoneid);
-	if (gangzone == nullptr)
-	{
-		return false;
-	}
-	return gangzone->isFlashingForPlayer(player);
+	return gangzone.isFlashingForPlayer(player);
 }
 
-SCRIPT_API(GangZoneGetPos, bool(cell gangzoneid, Vector2& min, Vector2& max))
+SCRIPT_API(GangZoneGetPos, bool(IGangZone& gangzone, Vector2& min, Vector2& max))
 {
-	IGangZone* gangzone = TryGetGangZone(gangzoneid);
-	if (gangzone == nullptr)
-	{
-		return false;
-	}
-	const GangZonePos& pos = gangzone->getPosition();
+	const GangZonePos& pos = gangzone.getPosition();
 	min = pos.min;
 	max = pos.max;
 	return true;
 }
 
-SCRIPT_API(UseGangZoneCheck, bool(cell gangzoneid, bool enable))
+SCRIPT_API(UseGangZoneCheck, bool(IGangZone& gangzone, bool enable))
 {
-	IGangZone* gangzone = TryGetGangZone(gangzoneid);
-	if (gangzone == nullptr)
-	{
-		return false;
-	}
 	IGangZonesComponent* component = PawnManager::Get()->gangzones;
 	if (component)
 	{
-		component->useGangZoneCheck(*gangzone, enable);
+		component->useGangZoneCheck(gangzone, enable);
 		return true;
 	}
 	return false;

--- a/Server/Components/Pawn/Scripting/Object/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Object/Natives.cpp
@@ -134,70 +134,40 @@ SCRIPT_API(IsObjectMoving, bool(IObject& object))
 	return object.isMoving();
 }
 
-SCRIPT_API(EditObject, bool(IPlayer& player, IObject& object))
+SCRIPT_API(EditObject, bool(IPlayerObjectData& data, IObject& object))
 {
-	IPlayerObjectData* playerData = queryExtension<IPlayerObjectData>(player);
-	if (playerData)
-	{
-		playerData->beginEditing(object);
-		return true;
-	}
-	return false;
+	data.beginEditing(object);
+	return true;
 }
 
-SCRIPT_API(SelectObject, bool(IPlayer& player))
+SCRIPT_API(SelectObject, bool(IPlayerObjectData& data))
 {
-	IPlayerObjectData* playerData = queryExtension<IPlayerObjectData>(player);
-	if (playerData)
-	{
-		playerData->beginSelecting();
-		return true;
-	}
-	return false;
+	data.beginSelecting();
+	return true;
 }
 
-SCRIPT_API(CancelEdit, bool(IPlayer& player))
+SCRIPT_API(CancelEdit, bool(IPlayerObjectData& data))
 {
-	IPlayerObjectData* playerData = queryExtension<IPlayerObjectData>(player);
-	if (playerData)
-	{
-		playerData->endEditing();
-		return true;
-	}
-	return false;
+	data.endEditing();
+	return true;
 }
 
-SCRIPT_API(BeginObjectEditing, bool(IPlayer& player, IObject& object))
+SCRIPT_API(BeginObjectEditing, bool(IPlayerObjectData& data, IObject& object))
 {
-	IPlayerObjectData* playerData = queryExtension<IPlayerObjectData>(player);
-	if (playerData)
-	{
-		playerData->beginEditing(object);
-		return true;
-	}
-	return false;
+	data.beginEditing(object);
+	return true;
 }
 
-SCRIPT_API(BeginObjectSelecting, bool(IPlayer& player))
+SCRIPT_API(BeginObjectSelecting, bool(IPlayerObjectData& data))
 {
-	IPlayerObjectData* playerData = queryExtension<IPlayerObjectData>(player);
-	if (playerData)
-	{
-		playerData->beginSelecting();
-		return true;
-	}
-	return false;
+	data.beginSelecting();
+	return true;
 }
 
-SCRIPT_API(EndObjectEditing, bool(IPlayer& player))
+SCRIPT_API(EndObjectEditing, bool(IPlayerObjectData& data))
 {
-	IPlayerObjectData* playerData = queryExtension<IPlayerObjectData>(player);
-	if (playerData)
-	{
-		playerData->endEditing();
-		return true;
-	}
-	return false;
+	data.endEditing();
+	return true;
 }
 
 SCRIPT_API(SetObjectMaterial, bool(IObject& object, int materialIndex, int modelId, const std::string& textureLibrary, const std::string& textureName, uint32_t materialColour))
@@ -342,15 +312,11 @@ SCRIPT_API(IsObjectNoCameraCol, bool(IObject& object))
 	return !object.getCameraCollision();
 }
 
-SCRIPT_API(GetObjectType, int(IPlayer& player, int objectid))
+SCRIPT_API(GetObjectType, int(IPlayerObjectData& data, int objectid))
 {
-	IPlayerObjectData* playerData = queryExtension<IPlayerObjectData>(player);
-	if (playerData)
+	if (data.get(objectid) != nullptr)
 	{
-		if (playerData->get(objectid) != nullptr)
-		{
-			return 2; // Player object type
-		}
+		return 2; // Player object type
 	}
 
 	IObjectsComponent* component = PawnManager::Get()->objects;

--- a/Server/Components/Pawn/Scripting/Object/PlayerNatives.cpp
+++ b/Server/Components/Pawn/Scripting/Object/PlayerNatives.cpp
@@ -11,24 +11,19 @@
 #include <iostream>
 #include "../../format.hpp"
 
-SCRIPT_API(CreatePlayerObject, int(IPlayer& player, int modelid, Vector3 position, Vector3 rotation, float drawDistance))
+SCRIPT_API_FAILRET(CreatePlayerObject, INVALID_OBJECT_ID, int(IPlayerObjectData& data, int modelid, Vector3 position, Vector3 rotation, float drawDistance))
 {
-	IPlayerObjectData* playerData = queryExtension<IPlayerObjectData>(player);
-	if (playerData)
+	IPlayerObject* object = data.create(modelid, position, rotation, drawDistance);
+	if (object)
 	{
-		IPlayerObject* object = playerData->create(modelid, position, rotation, drawDistance);
-		if (object)
-		{
-			return object->getID();
-		}
+		return object->getID();
 	}
-	return INVALID_OBJECT_ID;
+	return FailRet;
 }
 
-SCRIPT_API(DestroyPlayerObject, bool(IPlayer& player, IPlayerObject& object))
+SCRIPT_API(DestroyPlayerObject, bool(IPlayerObjectData& data, IPlayerObject& object))
 {
-	IPlayerObjectData* playerData = queryExtension<IPlayerObjectData>(player);
-	playerData->release(object.getID());
+	data.release(object.getID());
 	return true;
 }
 
@@ -139,26 +134,16 @@ SCRIPT_API(IsPlayerObjectMoving, bool(IPlayer& player, IPlayerObject& object))
 	return object.isMoving();
 }
 
-SCRIPT_API(EditPlayerObject, bool(IPlayer& player, IPlayerObject& object))
+SCRIPT_API(EditPlayerObject, bool(IPlayerObjectData& data, IPlayerObject& object))
 {
-	IPlayerObjectData* playerData = queryExtension<IPlayerObjectData>(player);
-	if (playerData)
-	{
-		playerData->beginEditing(object);
-		return true;
-	}
-	return false;
+	data.beginEditing(object);
+	return true;
 }
 
-SCRIPT_API(BeginPlayerObjectEditing, bool(IPlayer& player, IPlayerObject& object))
+SCRIPT_API(BeginPlayerObjectEditing, bool(IPlayerObjectData& data, IPlayerObject& object))
 {
-	IPlayerObjectData* playerData = queryExtension<IPlayerObjectData>(player);
-	if (playerData)
-	{
-		playerData->beginEditing(object);
-		return true;
-	}
-	return false;
+	data.beginEditing(object);
+	return true;
 }
 
 SCRIPT_API(SetPlayerObjectMaterial, bool(IPlayer& player, IPlayerObject& object, int materialIndex, int modelId, const std::string& textureLibrary, const std::string& textureName, uint32_t materialColour))

--- a/Server/Components/Pawn/Scripting/Pickup/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Pickup/Natives.cpp
@@ -10,16 +10,6 @@
 #include "sdk.hpp"
 #include <iostream>
 
-static IPickup* TryGetPickup(cell ref) noexcept
-{
-	auto pool = PawnManager::Get()->pickups;
-	if (pool)
-	{
-		return pool->get(pool->fromLegacyID(ref));
-	}
-	return nullptr;
-}
-
 SCRIPT_API(CreatePickup, int(int model, int type, Vector3 position, int virtualWorld))
 {
 	IPickupsComponent* component = PawnManager::Get()->pickups;
@@ -70,157 +60,97 @@ SCRIPT_API(AddStaticPickup, bool(int model, int type, Vector3 position, int virt
 	return false;
 }
 
-SCRIPT_API(DestroyPickup, bool(cell legacyid))
+SCRIPT_API(DestroyPickup, bool(int pickupid))
 {
 	IPickupsComponent* component = PawnManager::Get()->pickups;
 	if (component)
 	{
-		int realid = component->fromLegacyID(legacyid);
+		int realid = component->fromLegacyID(pickupid);
 		if (realid)
 		{
 			component->release(realid);
-			component->releaseLegacyID(legacyid);
+			component->releaseLegacyID(pickupid);
 			return true;
 		}
 	}
 	return false;
 }
 
-SCRIPT_API(IsValidPickup, bool(cell pickupid))
+SCRIPT_API(IsValidPickup, bool(IPickup& pickup))
 {
-	return TryGetPickup(pickupid) != nullptr;
-}
-
-SCRIPT_API(IsPickupStreamedIn, bool(IPlayer& player, cell pickupid))
-{
-	IPickup* pickup = TryGetPickup(pickupid);
-	if (pickup == nullptr)
-	{
-		return false;
-	}
-	return pickup->isStreamedInForPlayer(player);
-}
-
-SCRIPT_API(GetPickupPos, bool(cell pickupid, Vector3& pos))
-{
-	IPickup* pickup = TryGetPickup(pickupid);
-	if (pickup == nullptr)
-	{
-		return false;
-	}
-	pos = pickup->getPosition();
 	return true;
 }
 
-SCRIPT_API(GetPickupModel, int(cell pickupid))
+SCRIPT_API(IsPickupStreamedIn, bool(IPlayer& player, IPickup& pickup))
 {
-	IPickup* pickup = TryGetPickup(pickupid);
-	if (pickup == nullptr)
-	{
-		return 0;
-	}
-	return pickup->getModel();
+	return pickup.isStreamedInForPlayer(player);
 }
 
-SCRIPT_API(GetPickupType, int(cell pickupid))
+SCRIPT_API(GetPickupPos, bool(IPickup& pickup, Vector3& pos))
 {
-	IPickup* pickup = TryGetPickup(pickupid);
-	if (pickup == nullptr)
-	{
-		return -1;
-	}
-	return pickup->getType();
+	pos = pickup.getPosition();
+	return true;
 }
 
-SCRIPT_API(GetPickupVirtualWorld, int(cell pickupid))
+SCRIPT_API(GetPickupModel, int(IPickup& pickup))
 {
-	IPickup* pickup = TryGetPickup(pickupid);
-	if (pickup == nullptr)
-	{
-		return 0;
-	}
-	return pickup->getVirtualWorld();
+	return pickup.getModel();
 }
 
-SCRIPT_API(SetPickupPos, bool(cell pickupid, Vector3 pos, bool update))
+SCRIPT_API_FAILRET(GetPickupType, -1, int(IPickup& pickup))
 {
-	IPickup* pickup = TryGetPickup(pickupid);
-	if (pickup == nullptr)
-	{
-		return false;
-	}
+	return pickup.getType();
+}
+
+SCRIPT_API(GetPickupVirtualWorld, int(IPickup& pickup))
+{
+	return pickup.getVirtualWorld();
+}
+
+SCRIPT_API(SetPickupPos, bool(IPickup& pickup, Vector3 pos, bool update))
+{
 	if (update)
 	{
-		pickup->setPosition(pos);
+		pickup.setPosition(pos);
 	}
 	else
 	{
-		pickup->setPositionNoUpdate(pos);
+		pickup.setPositionNoUpdate(pos);
 	}
 	return true;
 }
 
-SCRIPT_API(SetPickupModel, bool(cell pickupid, int model, bool update))
+SCRIPT_API(SetPickupModel, bool(IPickup& pickup, int model, bool update))
 {
-	IPickup* pickup = TryGetPickup(pickupid);
-	if (pickup == nullptr)
-	{
-		return false;
-	}
-	pickup->setModel(model, update);
+	pickup.setModel(model, update);
 	return true;
 }
 
-SCRIPT_API(SetPickupType, bool(cell pickupid, int type, bool update))
+SCRIPT_API(SetPickupType, bool(IPickup& pickup, int type, bool update))
 {
-	IPickup* pickup = TryGetPickup(pickupid);
-	if (pickup == nullptr)
-	{
-		return false;
-	}
-	pickup->setType(type, update);
+	pickup.setType(type, update);
 	return true;
 }
 
-SCRIPT_API(SetPickupVirtualWorld, bool(cell pickupid, int virtualworld))
+SCRIPT_API(SetPickupVirtualWorld, bool(IPickup& pickup, int virtualworld))
 {
-	IPickup* pickup = TryGetPickup(pickupid);
-	if (pickup == nullptr)
-	{
-		return false;
-	}
-	pickup->setVirtualWorld(virtualworld);
+	pickup.setVirtualWorld(virtualworld);
 	return true;
 }
 
-SCRIPT_API(ShowPickupForPlayer, bool(IPlayer& player, cell pickupid))
+SCRIPT_API(ShowPickupForPlayer, bool(IPlayer& player, IPickup& pickup))
 {
-	IPickup* pickup = TryGetPickup(pickupid);
-	if (pickup == nullptr)
-	{
-		return false;
-	}
-	pickup->setPickupHiddenForPlayer(player, false);
+	pickup.setPickupHiddenForPlayer(player, false);
 	return true;
 }
 
-SCRIPT_API(HidePickupForPlayer, bool(IPlayer& player, cell pickupid))
+SCRIPT_API(HidePickupForPlayer, bool(IPlayer& player, IPickup& pickup))
 {
-	IPickup* pickup = TryGetPickup(pickupid);
-	if (pickup == nullptr)
-	{
-		return false;
-	}
-	pickup->setPickupHiddenForPlayer(player, true);
+	pickup.setPickupHiddenForPlayer(player, true);
 	return true;
 }
 
-SCRIPT_API(IsPickupHiddenForPlayer, bool(IPlayer& player, cell pickupid))
+SCRIPT_API(IsPickupHiddenForPlayer, bool(IPlayer& player, IPickup& pickup))
 {
-	IPickup* pickup = TryGetPickup(pickupid);
-	if (pickup == nullptr)
-	{
-		return false;
-	}
-	return pickup->isPickupHiddenForPlayer(player);
+	return pickup.isPickupHiddenForPlayer(player);
 }

--- a/Server/Components/Pawn/Scripting/Pickup/PlayerNatives.cpp
+++ b/Server/Components/Pawn/Scripting/Pickup/PlayerNatives.cpp
@@ -10,17 +10,6 @@
 #include "sdk.hpp"
 #include <iostream>
 
-static IPickup* TryGetPickup(IPlayer& player, cell ref) noexcept
-{
-	auto data = queryExtension<IPlayerPickupData>(player);
-	auto pool = PawnManager::Get()->pickups;
-	if (data && pool)
-	{
-		return pool->get(data->fromLegacyID(ref));
-	}
-	return nullptr;
-}
-
 SCRIPT_API(CreatePlayerPickup, int(IPlayer& player, int model, int type, Vector3 position, int virtualWorld))
 {
 	IPickupsComponent* component = PawnManager::Get()->pickups;
@@ -48,126 +37,81 @@ SCRIPT_API(CreatePlayerPickup, int(IPlayer& player, int model, int type, Vector3
 	return INVALID_PICKUP_ID;
 }
 
-SCRIPT_API(DestroyPlayerPickup, bool(IPlayer& player, cell legacyid))
+SCRIPT_API(DestroyPlayerPickup, bool(IPlayer& player, int pickupid))
 {
 	IPickupsComponent* component = PawnManager::Get()->pickups;
 	auto data = queryExtension<IPlayerPickupData>(player);
 	if (component && data)
 	{
-		int realid = data->fromLegacyID(legacyid);
+		int realid = data->fromLegacyID(pickupid);
 		if (realid)
 		{
 			component->release(realid);
-			data->releaseLegacyID(legacyid);
+			data->releaseLegacyID(pickupid);
 			return true;
 		}
 	}
 	return false;
 }
 
-SCRIPT_API(IsValidPlayerPickup, bool(IPlayer& player, cell pickupid))
+SCRIPT_API(IsValidPlayerPickup, bool(IPlayer& player, IPlayerPickup& pickup))
 {
-	return TryGetPickup(player, pickupid) != nullptr;
-}
-
-SCRIPT_API(IsPlayerPickupStreamedIn, bool(IPlayer& player, cell pickupid))
-{
-	IPickup* pickup = TryGetPickup(player, pickupid);
-	if (pickup == nullptr)
-	{
-		return false;
-	}
-	return pickup->isStreamedInForPlayer(player);
-}
-
-SCRIPT_API(GetPlayerPickupPos, bool(IPlayer& player, cell pickupid, Vector3& pos))
-{
-	IPickup* pickup = TryGetPickup(player, pickupid);
-	if (pickup == nullptr)
-	{
-		return false;
-	}
-	pos = pickup->getPosition();
 	return true;
 }
 
-SCRIPT_API(GetPlayerPickupModel, int(IPlayer& player, cell pickupid))
+SCRIPT_API(IsPlayerPickupStreamedIn, bool(IPlayer& player, IPlayerPickup& pickup))
 {
-	IPickup* pickup = TryGetPickup(player, pickupid);
-	if (pickup == nullptr)
-	{
-		return 0;
-	}
-	return pickup->getModel();
+	return pickup.isStreamedInForPlayer(player);
 }
 
-SCRIPT_API(GetPlayerPickupType, int(IPlayer& player, cell pickupid))
+SCRIPT_API(GetPlayerPickupPos, bool(IPlayer& player, IPlayerPickup& pickup, Vector3& pos))
 {
-	IPickup* pickup = TryGetPickup(player, pickupid);
-	if (pickup == nullptr)
-	{
-		return -1;
-	}
-	return pickup->getType();
+	pos = pickup.getPosition();
+	return true;
 }
 
-SCRIPT_API(GetPlayerPickupVirtualWorld, int(IPlayer& player, cell pickupid))
+SCRIPT_API(GetPlayerPickupModel, int(IPlayer& player, IPlayerPickup& pickup))
 {
-	IPickup* pickup = TryGetPickup(player, pickupid);
-	if (pickup == nullptr)
-	{
-		return 0;
-	}
-	return pickup->getVirtualWorld();
+	return pickup.getModel();
 }
 
-SCRIPT_API(SetPlayerPickupPos, bool(IPlayer& player, cell pickupid, Vector3 pos, bool update))
+SCRIPT_API_FAILRET(GetPlayerPickupType, -1, int(IPlayer& player, IPlayerPickup& pickup))
 {
-	IPickup* pickup = TryGetPickup(player, pickupid);
-	if (pickup == nullptr)
-	{
-		return false;
-	}
+	return pickup.getType();
+}
+
+SCRIPT_API(GetPlayerPickupVirtualWorld, int(IPlayer& player, IPlayerPickup& pickup))
+{
+	return pickup.getVirtualWorld();
+}
+
+SCRIPT_API(SetPlayerPickupPos, bool(IPlayer& player, IPlayerPickup& pickup, Vector3 pos, bool update))
+{
 	if (update)
 	{
-		pickup->setPosition(pos);
+		pickup.setPosition(pos);
 	}
 	else
 	{
-		pickup->setPositionNoUpdate(pos);
+		pickup.setPositionNoUpdate(pos);
 	}
 	return true;
 }
 
-SCRIPT_API(SetPlayerPickupModel, bool(IPlayer& player, cell pickupid, int model, bool update))
+SCRIPT_API(SetPlayerPickupModel, bool(IPlayer& player, IPlayerPickup& pickup, int model, bool update))
 {
-	IPickup* pickup = TryGetPickup(player, pickupid);
-	if (pickup == nullptr)
-	{
-		return false;
-	}
-	pickup->setModel(model, update);
+	pickup.setModel(model, update);
 	return true;
 }
 
-SCRIPT_API(SetPlayerPickupType, bool(IPlayer& player, cell pickupid, int type, bool update))
+SCRIPT_API(SetPlayerPickupType, bool(IPlayer& player, IPlayerPickup& pickup, int type, bool update))
 {
-	IPickup* pickup = TryGetPickup(player, pickupid);
-	if (pickup == nullptr)
-	{
-		return false;
-	}
-	pickup->setType(type, update);
+	pickup.setType(type, update);
 	return true;
 }
 
-SCRIPT_API(SetPlayerPickupVirtualWorld, bool(IPlayer& player, cell pickupid, int virtualworld))
+SCRIPT_API(SetPlayerPickupVirtualWorld, bool(IPlayer& player, IPlayerPickup& pickup, int virtualworld))
 {
-	IPickup* pickup = TryGetPickup(player, pickupid);
-	if (pickup == nullptr)
-	{
-		return false;
-	}
-	pickup->setVirtualWorld(virtualworld);
+	pickup.setVirtualWorld(virtualworld);
 	return true;
 }

--- a/Server/Components/Pawn/Scripting/Player/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Player/Natives.cpp
@@ -665,7 +665,7 @@ SCRIPT_API(GetPlayerSpecialAction, int(IPlayer& player))
 	return player.getAction();
 }
 
-SCRIPT_API_FAILRET(GetPlayerVehicleID, INVALID_PLAYER_ID, int(IPlayerVehicleData& data))
+SCRIPT_API_FAILRET(GetPlayerVehicleID, INVALID_VEHICLE_ID, int(IPlayerVehicleData& data))
 {
 	IVehicle* vehicle = data.getVehicle();
 	if (vehicle)

--- a/Server/Components/Pawn/Scripting/Player/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Player/Natives.cpp
@@ -603,13 +603,9 @@ SCRIPT_API(GetAnimationName, bool(int index, OutputOnlyString& lib, OutputOnlySt
 	return true;
 }
 
-SCRIPT_API(EditAttachedObject, bool(IPlayer& player, int index))
+SCRIPT_API(EditAttachedObject, bool(IPlayerObjectData& data, int index))
 {
-	IPlayerObjectData* data = queryExtension<IPlayerObjectData>(player);
-	if (data)
-	{
-		data->editAttachedObject(index);
-	}
+	data.editAttachedObject(index);
 	return true;
 }
 
@@ -713,14 +709,9 @@ SCRIPT_API(InterpolateCameraLookAt, bool(IPlayer& player, Vector3 from, Vector3 
 	return true;
 }
 
-SCRIPT_API(IsPlayerAttachedObjectSlotUsed, bool(IPlayer& player, int index))
+SCRIPT_API(IsPlayerAttachedObjectSlotUsed, bool(IPlayerObjectData& data, int index))
 {
-	IPlayerObjectData* data = queryExtension<IPlayerObjectData>(player);
-	if (data)
-	{
-		return data->hasAttachedObject(index);
-	}
-	return false;
+	return data.hasAttachedObject(index);
 }
 
 SCRIPT_API(AttachCameraToObject, bool(IPlayer& player, IObject& object))
@@ -830,52 +821,37 @@ SCRIPT_API(PlayCrimeReportForPlayer, bool(IPlayer& player, IPlayer& suspect, int
 	return player.playerCrimeReport(suspect, crime);
 }
 
-SCRIPT_API(RemovePlayerAttachedObject, bool(IPlayer& player, int index))
+SCRIPT_API(RemovePlayerAttachedObject, bool(IPlayerObjectData& data, int index))
 {
-	IPlayerObjectData* data = queryExtension<IPlayerObjectData>(player);
-	if (data)
-	{
-		data->removeAttachedObject(index);
-		return true;
-	}
-	return false;
+	data.removeAttachedObject(index);
+	return true;
 }
 
-SCRIPT_API(SetPlayerAttachedObject, bool(IPlayer& player, int index, int modelid, int bone, Vector3 offset, Vector3 rotation, Vector3 scale, uint32_t materialcolor1, uint32_t materialcolor2))
+SCRIPT_API(SetPlayerAttachedObject, bool(IPlayerObjectData& data, int index, int modelid, int bone, Vector3 offset, Vector3 rotation, Vector3 scale, uint32_t materialcolor1, uint32_t materialcolor2))
 {
-	IPlayerObjectData* data = queryExtension<IPlayerObjectData>(player);
-	if (data)
-	{
-		ObjectAttachmentSlotData attachment;
-		attachment.model = modelid;
-		attachment.bone = bone;
-		attachment.offset = offset;
-		attachment.rotation = rotation;
-		attachment.scale = scale;
-		attachment.colour1 = Colour::FromARGB(materialcolor1);
-		attachment.colour2 = Colour::FromARGB(materialcolor2);
-		data->setAttachedObject(index, attachment);
-		return true;
-	}
-	return false;
+	ObjectAttachmentSlotData attachment;
+	attachment.model = modelid;
+	attachment.bone = bone;
+	attachment.offset = offset;
+	attachment.rotation = rotation;
+	attachment.scale = scale;
+	attachment.colour1 = Colour::FromARGB(materialcolor1);
+	attachment.colour2 = Colour::FromARGB(materialcolor2);
+	data.setAttachedObject(index, attachment);
+	return true;
 }
 
-SCRIPT_API(GetPlayerAttachedObject, bool(IPlayer& player, int index, int& modelid, int& bone, Vector3& offset, Vector3& rotation, Vector3& scale, uint32_t& materialcolor1, uint32_t& materialcolor2))
+SCRIPT_API(GetPlayerAttachedObject, bool(IPlayerObjectData& data, int index, int& modelid, int& bone, Vector3& offset, Vector3& rotation, Vector3& scale, uint32_t& materialcolor1, uint32_t& materialcolor2))
 {
-	IPlayerObjectData* data = queryExtension<IPlayerObjectData>(player);
-	if (data)
-	{
-		ObjectAttachmentSlotData attachment = data->getAttachedObject(index);
-		modelid = attachment.model;
-		bone = attachment.bone;
-		offset = attachment.offset;
-		rotation = attachment.rotation;
-		scale = attachment.scale;
-		materialcolor1 = attachment.colour1.ARGB();
-		materialcolor2 = attachment.colour2.ARGB();
-		return true;
-	}
-	return false;
+	ObjectAttachmentSlotData attachment = data.getAttachedObject(index);
+	modelid = attachment.model;
+	bone = attachment.bone;
+	offset = attachment.offset;
+	rotation = attachment.rotation;
+	scale = attachment.scale;
+	materialcolor1 = attachment.colour1.ARGB();
+	materialcolor2 = attachment.colour2.ARGB();
+	return true;
 }
 
 SCRIPT_API(SetPlayerFacingAngle, bool(IPlayer& player, float angle))
@@ -925,26 +901,16 @@ SCRIPT_API(GetPlayerCameraZoom, float(IPlayer& player))
 	return player.getAimData().camZoom;
 }
 
-SCRIPT_API(SelectTextDraw, bool(IPlayer& player, uint32_t hoverColour))
+SCRIPT_API(SelectTextDraw, bool(IPlayerTextDrawData& data, uint32_t hoverColour))
 {
-	IPlayerTextDrawData* data = queryExtension<IPlayerTextDrawData>(player);
-	if (data)
-	{
-		data->beginSelection(Colour::FromRGBA(hoverColour));
-		return true;
-	}
-	return false;
+	data.beginSelection(Colour::FromRGBA(hoverColour));
+	return true;
 }
 
-SCRIPT_API(CancelSelectTextDraw, bool(IPlayer& player))
+SCRIPT_API(CancelSelectTextDraw, bool(IPlayerTextDrawData& data))
 {
-	IPlayerTextDrawData* data = queryExtension<IPlayerTextDrawData>(player);
-	if (data)
-	{
-		data->endSelection();
-		return true;
-	}
-	return false;
+	data.endSelection();
+	return true;
 }
 
 SCRIPT_API(SendClientCheck, bool(IPlayer& player, int actionType, int address, int offset, int count))
@@ -975,14 +941,9 @@ SCRIPT_API(gpci, int(IPlayer& player, OutputOnlyString& output))
 	return std::get<StringView>(output).length();
 }
 
-SCRIPT_API(IsPlayerAdmin, bool(IPlayer& player))
+SCRIPT_API(IsPlayerAdmin, bool(IPlayerConsoleData& data))
 {
-	IPlayerConsoleData* data = queryExtension<IPlayerConsoleData>(player);
-	if (data)
-	{
-		return data->hasConsoleAccess();
-	}
-	return false;
+	return data.hasConsoleAccess();
 }
 
 SCRIPT_API(Kick, bool(IPlayer& player))
@@ -1152,15 +1113,10 @@ SCRIPT_API(GetPlayerGravity, float(IPlayer& player))
 	return player.getGravity();
 }
 
-SCRIPT_API(SetPlayerAdmin, bool(IPlayer& player, bool set))
+SCRIPT_API(SetPlayerAdmin, bool(IPlayerConsoleData& data, bool set))
 {
-	IPlayerConsoleData* data = queryExtension<IPlayerConsoleData>(player);
-	if (data)
-	{
-		data->setConsoleAccessibility(set);
-		return true;
-	}
-	return false;
+	data.setConsoleAccessibility(set);
+	return true;
 }
 
 SCRIPT_API(IsPlayerSpawned, bool(IPlayer& player))


### PR DESCRIPTION
This PR declares `IPickup` , `IPlayerPickup`, `IGangZone` and `IPlayerGangZone` in SDK, derived from a base class now, so it can be used in ParamCast mechanism. Before that in our native declaration files we were using raw int32 params and having repetitive code to fetch related entity with it and do the checks in each native code block, so now using two newly provided macros, we can have param cast for entities in mixed pools.

#### Note: This is the first step for me to add per-player actors easier.

Also there are some player data param casts for less repetitive code in many other places.
 