### PR TITLE
FIx encoding of AMXFILE environment variable value for Windows.

### DIFF
--- a/Server/Components/Pawn/main.cpp
+++ b/Server/Components/Pawn/main.cpp
@@ -122,6 +122,8 @@ public:
 		{
 			ghc::filesystem::create_directory(scriptfilesPath);
 		}
+
+#if !defined(GHC_USE_WCHAR_T)
 		std::string amxFileEnvVar = scriptfilesPath.string();
 
 		amxFileEnvVar.insert(0, "AMXFILE=");
@@ -132,6 +134,17 @@ public:
 		memcpy(amxFileEnvVarCString, amxFileEnvVar.c_str(), size + 1);
 
 		putenv(amxFileEnvVarCString);
+
+#else
+
+		std::wstring wstr_path = scriptfilesPath.wstring();
+		std::wstring::size_type size = wstr_path.size();
+
+		wchar_t* path = new wchar_t[size + 1];
+		memcpy((void*)path, (void*)wstr_path.c_str(), (size + 1) * sizeof(wchar_t));
+		
+		_wputenv_s(L"AMXFILE", path);
+#endif
 	}
 
 	void onInit(IComponentList* components) override


### PR DESCRIPTION
This should fix https://github.com/openmultiplayer/open.mp/issues/697