### PR TITLE
Fix object data initialization and event priority conflict with pawn

### DIFF
--- a/Server/Components/Objects/objects_impl.hpp
+++ b/Server/Components/Objects/objects_impl.hpp
@@ -417,6 +417,8 @@ public:
 
 	void onPoolEntryDestroyed(IPlayer& player) override;
 
+	void onPoolEntryCreated(IPlayer& player) override;
+
 	void onPlayerStreamIn(IPlayer& player, IPlayer& forPlayer) override;
 
 	// Pre-spawn so you can safely attach onPlayerSpawn

--- a/Server/Components/Pawn/Scripting/Impl.cpp
+++ b/Server/Components/Pawn/Scripting/Impl.cpp
@@ -98,7 +98,7 @@ void Scripting::addEvents() const
 	if (mgr->players)
 	{
 		mgr->players->getPlayerSpawnDispatcher().addEventHandler(PlayerEvents::Get());
-		mgr->players->getPlayerConnectDispatcher().addEventHandler(PlayerEvents::Get(), EventPriority_FairlyLow);
+		mgr->players->getPlayerConnectDispatcher().addEventHandler(PlayerEvents::Get());
 		mgr->players->getPlayerStreamDispatcher().addEventHandler(PlayerEvents::Get());
 		mgr->players->getPlayerTextDispatcher().addEventHandler(PlayerEvents::Get());
 		mgr->players->getPlayerShotDispatcher().addEventHandler(PlayerEvents::Get());


### PR DESCRIPTION
1.  Remove pawn comp player connect event priority
Because now there are issues with Objects components sending
CreateObject RPCs on connect sooner than Pawn calling RemoveBuildingForPlayer
This way, created objects are again removed with game mechanis after
receiving RemoveBuildingForPlayer

2. Initialize player object data on player pool entry create