### PR TITLE
Fix issue with atcprintf not incrementing output length when adding - in trailing zero mode

### DIFF
--- a/Server/Components/Pawn/format.cpp
+++ b/Server/Components/Pawn/format.cpp
@@ -429,6 +429,7 @@ void AddInt(U** buf_p, size_t& maxlen, int val, int width, int flags)
 		if (flags & ZEROPAD)
 		{
 			*buf++ = '-';
+			maxlen--;
 		}
 		else
 		{


### PR DESCRIPTION
Fixes #742