### PR TITLE
return modelid in GetPlayerObjectMaterial

### DIFF
--- a/Server/Components/Pawn/Scripting/Object/PlayerNatives.cpp
+++ b/Server/Components/Pawn/Scripting/Object/PlayerNatives.cpp
@@ -241,6 +241,7 @@ SCRIPT_API(GetPlayerObjectMaterial, bool(IPlayer& player, IPlayerObject& object,
 	bool result = object.getMaterialData(materialIndex, data);
 	if (result)
 	{
+		modelid = data->model;
 		textureLibrary = data->textOrTXD;
 		textureName = data->fontOrTexture;
 		materialColour = data->materialColour.ARGB();


### PR DESCRIPTION
You forgot pass `modelid` in `GetPlayerObjectMaterial`