### PR TITLE
Fix amx_Allot trying to access invalid memory when data size is higher than amx STK size

### DIFF
--- a/Server/Components/Pawn/Script/Script.cpp
+++ b/Server/Components/Pawn/Script/Script.cpp
@@ -12,7 +12,6 @@
 */
 
 #define _Static_assert static_assert
-#define STKMARGIN ((cell)(16 * sizeof(cell))) // from amx.c
 
 #include <assert.h>
 #include <stdarg.h>

--- a/Server/Components/Pawn/Script/Script.cpp
+++ b/Server/Components/Pawn/Script/Script.cpp
@@ -473,6 +473,11 @@ int AMXAPI amx_Allot(AMX* amx, int cells, cell* amx_addr, cell** phys_addr)
 
 	if (amx->stk < amx->hea + cells * sizeof(cell))
 	{
+		PawnManager::Get()->core->logLn(LogLevel::Error, "Unable to find enough memory for your data.");
+		PawnManager::Get()->core->logLn(LogLevel::Error, "Size: %d bytes, Available space: %d bytes, Need extra size: %d bytes",
+			amx->hea + cells * sizeof(cell), amx->stk, amx->hea + cells * sizeof(cell) - amx->stk);
+		PawnManager::Get()->core->logLn(LogLevel::Error, "You can increase your available memory size by using `#pragma dynamic %d`.",
+			amx->hea / sizeof(cell) + cells);
 		return AMX_ERR_MEMORY;
 	}
 

--- a/Server/Components/Pawn/Script/Script.cpp
+++ b/Server/Components/Pawn/Script/Script.cpp
@@ -474,10 +474,10 @@ int AMXAPI amx_Allot(AMX* amx, int cells, cell* amx_addr, cell** phys_addr)
 	if (amx->stk < amx->hea + cells * sizeof(cell))
 	{
 		PawnManager::Get()->core->logLn(LogLevel::Error, "Unable to find enough memory for your data.");
-		PawnManager::Get()->core->logLn(LogLevel::Error, "Size: %d bytes, Available space: %d bytes, Need extra size: %d bytes",
-			amx->hea + cells * sizeof(cell), amx->stk, amx->hea + cells * sizeof(cell) - amx->stk);
-		PawnManager::Get()->core->logLn(LogLevel::Error, "You can increase your available memory size by using `#pragma dynamic %d`.",
-			amx->hea / sizeof(cell) + cells);
+		PawnManager::Get()->core->logLn(LogLevel::Error, "Size: %i bytes, Available space: %i bytes, Need extra size: %i bytes",
+			int(amx->hea + cells * sizeof(cell)), amx->stk, int(amx->hea + cells * sizeof(cell) - amx->stk));
+		PawnManager::Get()->core->logLn(LogLevel::Error, "You can increase your available memory size by using `#pragma dynamic %i`.",
+			int(amx->hea / sizeof(cell) + cells));
 		return AMX_ERR_MEMORY;
 	}
 

--- a/Server/Components/Pawn/Script/Script.cpp
+++ b/Server/Components/Pawn/Script/Script.cpp
@@ -489,7 +489,6 @@ __attribute__((noinline)) int AMXAPI amx_Release_impl(AMX* amx, cell amx_addr)
 	return AMX_ERR_NONE;
 }
 
-
 /// Pass-through to a noinline function to avoid adding complex instructions to the prologue that sampgdk can't handle
 /// This should work in every case as both JMP and CALL are at least 5 bytes in size;
 /// even in the minimal case it's guaranteed to contain a single JMP which is what sampgdk needs for a hook

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -61,7 +61,9 @@ if(BUILD_SERVER)
 				-DAMX_FILENO_CHECKS
 
 				# Disable default amx_FindPublic implementation because we want our own more performant one
-				AMX_ALIGN AMX_ALLOT AMX_CLEANUP AMX_CLONE AMX_DEFCALLBACK AMX_EXEC AMX_FLAGS AMX_GETADDR
+				# Also disable amx_Allot because we want to check if we have enough memory when we are passing data
+				# Which is more than available memory, so instead of a crash, we let user know about it.
+				AMX_ALIGN AMX_CLEANUP AMX_CLONE AMX_DEFCALLBACK AMX_FLAGS AMX_GETADDR
 				AMX_INIT AMX_MEMINFO AMX_NAMELENGTH AMX_NATIVEINFO AMX_PUSHXXX
 				AMX_RAISEERROR AMX_REGISTER AMX_SETCALLBACK AMX_SETDEBUGHOOK
 				AMX_XXXNATIVES AMX_XXXPUBVARS AMX_XXXSTRING AMX_XXXTAGS AMX_XXXUSERDATA AMX_UTF8XXX


### PR DESCRIPTION
This PR prevents server from crashing when `amx_Allot` wrongfully returns `AMX_ERR_NONE` and servers thinks it was successful when data size is higher than STK size, by simply returning `AMX_ERR_MEMORY` on when that situation happens and also printing a message about it, while hinting the user what they can do to fix it in their pawn code.

Example:
```log
[2023-12-28T19:13:21+0330] [Error] Unable to find enough memory for your data.
[2023-12-28T19:13:21+0330] [Error] Size: 4195184 bytes, Available space: 17256 bytes, Need extra size: 4177928 bytes
[2023-12-28T19:13:21+0330] [Error] You can increase your available memory size by using `#pragma dynamic 1048796`.
[2023-12-28T19:13:21+0330] [Error] Out of memory
``` 