### PR TITLE
52 isn't a valid damage reason

### DIFF
--- a/SDK/include/utils.hpp
+++ b/SDK/include/utils.hpp
@@ -18,13 +18,15 @@ inline StringView trim(StringView view)
 
 inline bool IsWeaponForTakenDamageValid(int weapon)
 {
-	auto slot = WeaponSlotData(weapon).slot();
-	if (slot == INVALID_WEAPON_SLOT)
+	switch (weapon)
 	{
-		if (weapon < 49 || weapon > 54)
-		{
-			return false;
-		}
+	case 49: // Run over
+	case 50: // Helicopter blades
+	case 51: // Explosion
+	case 53: // Drowned
+	case 54: // Collision
+		return true;
+	default:
+		return (WeaponSlotData(weapon).slot() != INVALID_WEAPON_SLOT);
 	}
-	return true;
 }


### PR DESCRIPTION
Excludes `52` being accepted as a valid damage reason, where previously `49 <= x <= 54` accepted it.