### PR TITLE
Add banners & discord configs and send through query

### DIFF
--- a/Server/Components/LegacyNetwork/Query/query.cpp
+++ b/Server/Components/LegacyNetwork/Query/query.cpp
@@ -131,7 +131,8 @@ void Query::buildExtraServerInfoBuffer()
 		return;
 	}
 
-	uint32_t discordLinkLength = std::min(discordLink.length(), MAX_ACCEPTABLE_DISCORD_LINK_SIZE);
+	// Set discord link length to 0 if it's over acceptable length (max size defined by discord itself)
+	uint32_t discordLinkLength = MAX_ACCEPTABLE_DISCORD_LINK_SIZE < discordLink.length() ? 0 : discordLink.length();
 	uint32_t lightBannerUrlLength = std::min(lightBannerUrl.length(), MAX_ACCEPTABLE_BANNER_URL_SIZE);
 	uint32_t darkBannerUrlLength = std::min(darkBannerUrl.length(), MAX_ACCEPTABLE_BANNER_URL_SIZE);
 

--- a/Server/Components/LegacyNetwork/Query/query.hpp
+++ b/Server/Components/LegacyNetwork/Query/query.hpp
@@ -49,6 +49,7 @@ public:
 	{
 		buildServerInfoBuffer();
 		buildRulesBuffer();
+		buildExtraServerInfoBuffer();
 	}
 
 	void setMaxPlayers(uint16_t value)
@@ -143,6 +144,21 @@ public:
 		language = String(value);
 	}
 
+	void setDiscordLink(StringView value)
+	{
+		discordLink = String(value);
+	}
+
+	void setLightBannerUrl(StringView value)
+	{
+		lightBannerUrl = String(value);
+	}
+
+	void setDarkBannerUrl(StringView value)
+	{
+		darkBannerUrl = String(value);
+	}
+
 private:
 	ICore* core = nullptr;
 	IConsoleComponent* console = nullptr;
@@ -151,6 +167,9 @@ private:
 	String gameModeName = "Unknown";
 	String language = "EN";
 	String rconPassword;
+	String discordLink = "";
+	String lightBannerUrl = "";
+	String darkBannerUrl = "";
 	bool passworded = false;
 	bool logQueries = false;
 	bool rconEnabled = false;
@@ -167,7 +186,11 @@ private:
 	std::unique_ptr<char[]> rulesBuffer;
 	size_t rulesBufferLength = 0;
 
+	std::unique_ptr<char[]> extraInfoBuffer;
+	size_t extraInfoBufferLength = 0;
+
 	void buildPlayerInfoBuffer(IPlayer* except = nullptr);
 	void updateServerInfoBufferPlayerCount(IPlayer* except = nullptr);
 	void buildServerInfoBuffer();
+	void buildExtraServerInfoBuffer();
 };

--- a/Server/Components/LegacyNetwork/legacy_network_impl.cpp
+++ b/Server/Components/LegacyNetwork/legacy_network_impl.cpp
@@ -755,19 +755,19 @@ void RakNetLegacyNetwork::update()
 		query.setRuleValue<false>("weburl", String(website));
 	}
 
-	StringView discordLink = config.getString("discord");
+	StringView discordLink = config.getString("discord.invite");
 	if (!discordLink.empty())
 	{
 		query.setDiscordLink(discordLink);
 	}
 
-	StringView bannerUrl = config.getString("banner_light");
+	StringView bannerUrl = config.getString("banners.light");
 	if (!bannerUrl.empty())
 	{
 		query.setLightBannerUrl(bannerUrl);
 	}
 
-	bannerUrl = config.getString("banner_dark");
+	bannerUrl = config.getString("banners.dark");
 	if (!bannerUrl.empty())
 	{
 		query.setDarkBannerUrl(bannerUrl);

--- a/Server/Components/LegacyNetwork/legacy_network_impl.cpp
+++ b/Server/Components/LegacyNetwork/legacy_network_impl.cpp
@@ -755,6 +755,24 @@ void RakNetLegacyNetwork::update()
 		query.setRuleValue<false>("weburl", String(website));
 	}
 
+	StringView discordLink = config.getString("discord");
+	if (!discordLink.empty())
+	{
+		query.setDiscordLink(discordLink);
+	}
+
+	StringView bannerUrl = config.getString("banner_light");
+	if (!bannerUrl.empty())
+	{
+		query.setLightBannerUrl(bannerUrl);
+	}
+
+	bannerUrl = config.getString("banner_dark");
+	if (!bannerUrl.empty())
+	{
+		query.setDarkBannerUrl(bannerUrl);
+	}
+
 	query.setRuleValue<false>("worldtime", String(std::to_string(*config.getInt("game.time")) + ":00"));
 
 	StringView rconPassword = config.getString("rcon.password");

--- a/Server/Source/core_impl.hpp
+++ b/Server/Source/core_impl.hpp
@@ -59,6 +59,9 @@ static const std::map<String, ConfigStorage> Defaults {
 	{ "sleep", 5.0f },
 	{ "use_dyn_ticks", true },
 	{ "website", String("open.mp") },
+	{ "banner_light", String("") },
+	{ "banner_dark", String("") },
+	{ "discord", String("") },
 	// game
 	{ "game.allow_interior_weapons", true },
 	{ "game.chat_radius", 200.0f },

--- a/Server/Source/core_impl.hpp
+++ b/Server/Source/core_impl.hpp
@@ -59,9 +59,6 @@ static const std::map<String, ConfigStorage> Defaults {
 	{ "sleep", 5.0f },
 	{ "use_dyn_ticks", true },
 	{ "website", String("open.mp") },
-	{ "banner_light", String("") },
-	{ "banner_dark", String("") },
-	{ "discord", String("") },
 	// game
 	{ "game.allow_interior_weapons", true },
 	{ "game.chat_radius", 200.0f },
@@ -130,6 +127,11 @@ static const std::map<String, ConfigStorage> Defaults {
 	{ "rcon.allow_teleport", false },
 	{ "rcon.enable", false },
 	{ "rcon.password", String("") }, // Set default to empty instead of changeme, so server starts with disabled rcon without config file
+	// banners
+	{ "banners.light", String("") },
+	{ "banners.dark", String("") },
+	// discord
+	{ "discord.invite", String("") },
 };
 
 // Provide automatic Defaults → JSON conversion in Config


### PR DESCRIPTION
new configs are now available, example:
```json
{
    "discord": "https://discord.gg/samp",
    "banner_light": "https://github.com/openmultiplayer/graphics/blob/master/rendered/wordmark-light-mono.png?raw=true",
    "banner_dark": "https://github.com/openmultiplayer/graphics/blob/master/rendered/wordmark-coloured.png?raw=true"
}
```
then with query `o`, instead of sending same receiving back, we send these.
max. banner url length is 120 chars.
max. discord url length is 50 chars.