### PR TITLE
RakNet crash fixes, performance improvements, fix ordering channels for some RPCs

### DIFF
--- a/Server/Components/LegacyNetwork/legacy_network_impl.cpp
+++ b/Server/Components/LegacyNetwork/legacy_network_impl.cpp
@@ -23,6 +23,7 @@ RakNetLegacyNetwork::RakNetLegacyNetwork()
 	, rakNetServer(*RakNet::RakNetworkFactory::GetRakServerInterface())
 {
 	rakNetServer.SetMTUSize(512);
+	playerRemoteSystem.fill(nullptr);
 
 	RPCHOOK(0);
 	RPCHOOK(1);
@@ -449,6 +450,8 @@ void RakNetLegacyNetwork::OnPlayerConnect(RakNet::RPCParameters* rpcParams, void
 				}
 
 				network->networkEventDispatcher.dispatch(&NetworkEventHandler::onPeerConnect, *newPeer);
+
+				network->playerRemoteSystem[newPeer->getID()] = remoteSystem;
 				return;
 			}
 		}
@@ -522,6 +525,7 @@ void RakNetLegacyNetwork::OnRakNetDisconnect(RakNet::PlayerIndex rid, PeerDiscon
 	}
 
 	playerFromRakIndex[rid] = nullptr;
+	playerRemoteSystem[player->getID()] = nullptr;
 	networkEventDispatcher.dispatch(&NetworkEventHandler::onPeerDisconnect, *player, reason);
 }
 

--- a/Shared/NetCode/core.hpp
+++ b/Shared/NetCode/core.hpp
@@ -368,7 +368,7 @@ namespace RPC
 		}
 	};
 
-	struct SendClientMessage : NetworkPacketBase<93, NetworkPacketType::RPC, OrderingChannel_Unordered>
+	struct SendClientMessage : NetworkPacketBase<93, NetworkPacketType::RPC, OrderingChannel_SyncRPC>
 	{
 		HybridString<128> Message;
 		Colour Col;
@@ -385,7 +385,7 @@ namespace RPC
 		}
 	};
 
-	struct PlayerRequestChatMessage : NetworkPacketBase<101, NetworkPacketType::RPC, OrderingChannel_Unordered>
+	struct PlayerRequestChatMessage : NetworkPacketBase<101, NetworkPacketType::RPC, OrderingChannel_SyncRPC>
 	{
 
 		HybridString<128> message;
@@ -399,7 +399,7 @@ namespace RPC
 		}
 	};
 
-	struct PlayerChatMessage : NetworkPacketBase<101, NetworkPacketType::RPC, OrderingChannel_Unordered>
+	struct PlayerChatMessage : NetworkPacketBase<101, NetworkPacketType::RPC, OrderingChannel_SyncRPC>
 	{
 		int PlayerID;
 		HybridString<128> message;
@@ -415,7 +415,7 @@ namespace RPC
 		}
 	};
 
-	struct PlayerRequestCommandMessage : NetworkPacketBase<50, NetworkPacketType::RPC, OrderingChannel_Unordered>
+	struct PlayerRequestCommandMessage : NetworkPacketBase<50, NetworkPacketType::RPC, OrderingChannel_SyncRPC>
 	{
 
 		HybridString<128> message;
@@ -448,7 +448,7 @@ namespace RPC
 		}
 	};
 
-	struct PlayerCommandMessage : NetworkPacketBase<50, NetworkPacketType::RPC, OrderingChannel_Unordered>
+	struct PlayerCommandMessage : NetworkPacketBase<50, NetworkPacketType::RPC, OrderingChannel_SyncRPC>
 	{
 		HybridString<128> message;
 
@@ -463,7 +463,7 @@ namespace RPC
 		}
 	};
 
-	struct SendDeathMessage : NetworkPacketBase<55, NetworkPacketType::RPC, OrderingChannel_Unordered>
+	struct SendDeathMessage : NetworkPacketBase<55, NetworkPacketType::RPC, OrderingChannel_SyncRPC>
 	{
 		bool HasKiller;
 		int KillerID;


### PR DESCRIPTION
## 1.  RakNet Crashes  
There are many places in RakNet you seepacket data being deleted using `delete` or `delete[]` and while it works fine, there are cases where double deletion happens, it's very random so the cause isn't clear yet. But finding the actual problem and fixing was easier than reproducing it (Check here: https://github.com/openmultiplayer/RakNet/compare/3efbe1b9ff77647f5fabaf7bc1824cf438fea7a3...7f4f20d6745a312df1f121f0e5406212347a5565#diff-dcf7bd2af9b6ecac1d8af94416ca373c3a6f7a9528852c176dc36ae02e02223f)

## 2.  RakNet related improvements
1. So for first one, there's https://github.com/openmultiplayer/open.mp/commit/94a43bfe62b21fedda6c955b21b6a9bb60f89c02 , the explanation for this would be how `GetRemoteSystemFromPlayerID` works internally in RakNet, it loops through all available slots (not taken, not empty, all of them) and tries to search for the same `PlayerID` and return `RemoteSystemStruct` ptr for it. A huge improvement can be made by just caching and storing a pointer of `RemoteSystemStruct` on connect and releasing it on disconnect on open.mp side of the project, to use it for re-implementing `GetLastPing` for `IPlayer::getPing` and `INetwork::getPing`. This also massively helps ScoreAndPingsUpdate RPC since it loops through all players and calls `getPing` for each of them, resulting a `player count * max players` loop, for full servers it's `1000 * 1000` iterations for nothing.
2. Then there's `playerIndexes` flat hash map used internally in RakNet, for way faster `PlayerID` and player `index` lookup and use it in different places in RakNet to, again, improve performance noticeably and get rid of unnecessary overhead of looping through all slots every time you want to find a player index based on their `RakNet::PlayerID` which is a linear search.
 
## 2. Fix chat RPC ordering channels
Almost all chat related RPCs had wrong ordering channels defined, as `OrderingChannel_Unordered`, while they should be anything ordered, preferably `OrderingChannel_SyncRPC`.