### PR TITLE
Revert "Support LFS"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,6 @@ elseif(UNIX)
 		set(TARGET_BUILD_ARCH "x86" CACHE STRING "The architecture to build for.")
 		set(SHARED_OPENSSL TRUE CACHE BOOL "Whether to dynamically link the OpenSSL library")
 		set(STATIC_STDCXX FALSE CACHE BOOL "Whether to statically link against libc++.")
-  		add_compile_definitions("_FILE_OFFSET_BITS=64")
 	# Apple Clang
 	else()
 		set(CMAKE_CXX_STDLIB "libc++" CACHE STRING "The standard library to use.")


### PR DESCRIPTION
Reverting this change because it makes crashdetect not work properly

![image](https://github.com/openmultiplayer/open.mp/assets/34688664/cd1307af-0651-4255-8158-cdd3d6fc7d4e)

and

https://discord.com/channels/231799104731217931/231799180127895553/1200792626098622624
on samp discord