### PR TITLE
Boundary between objects on the client (tested)

### DIFF
--- a/SDK/include/values.hpp
+++ b/SDK/include/values.hpp
@@ -4,7 +4,7 @@
 
 constexpr int MAX_SEATS = 4;
 constexpr int PLAYER_POOL_SIZE = 1000;
-constexpr int VEHICLE_POOL_SIZE = 3000;
+constexpr int VEHICLE_POOL_SIZE = 2000;
 constexpr int CLASS_POOL_SIZE = 320;
 constexpr int OBJECT_POOL_SIZE = 2000;
 constexpr int OBJECT_POOL_SIZE_037 = 1000;

--- a/SDK/include/values.hpp
+++ b/SDK/include/values.hpp
@@ -4,7 +4,7 @@
 
 constexpr int MAX_SEATS = 4;
 constexpr int PLAYER_POOL_SIZE = 1000;
-constexpr int VEHICLE_POOL_SIZE = 2000;
+constexpr int VEHICLE_POOL_SIZE = 3000;
 constexpr int CLASS_POOL_SIZE = 320;
 constexpr int OBJECT_POOL_SIZE = 2000;
 constexpr int OBJECT_POOL_SIZE_037 = 1000;

--- a/Server/Components/Objects/objects_impl.hpp
+++ b/Server/Components/Objects/objects_impl.hpp
@@ -416,11 +416,6 @@ public:
 		return storage._entries();
 	}
 
-	ClientVersion getClientVersion() const override
-	{
-		return version_;
-	}
-	
 	void onPoolEntryDestroyed(IPlayer& player) override;
 
 	void onPoolEntryCreated(IPlayer& player) override;

--- a/Server/Components/Objects/objects_impl.hpp
+++ b/Server/Components/Objects/objects_impl.hpp
@@ -352,9 +352,8 @@ public:
 
 		Object* obj = storage.get(objid);
 		for (IPlayer* player : players->entries())
-		{
-			if(players->getClientVersion() != ClientVersion::ClientVersion_SAMP_03DL && < freeIdx < OBJECT_POOL_SIZE_037)
-				obj->createForPlayer(*player);
+		{			
+			obj->createForPlayer(*player);
 		}
 
 		return obj;
@@ -417,6 +416,11 @@ public:
 		return storage._entries();
 	}
 
+	ClientVersion getClientVersion() const override
+	{
+		return version_;
+	}
+	
 	void onPoolEntryDestroyed(IPlayer& player) override;
 
 	void onPoolEntryCreated(IPlayer& player) override;

--- a/Server/Components/Objects/objects_impl.hpp
+++ b/Server/Components/Objects/objects_impl.hpp
@@ -330,6 +330,12 @@ public:
 
 			freeIdx = storage.findFreeIndex(freeIdx + 1);
 		}
+		// The server accepts connections from 0.3.7 clients.
+		// We can't create more than 1000 objects.
+		/*if (compatModeEnabled && freeIdx >= OBJECT_POOL_SIZE_037)
+		{
+			return nullptr;
+		}		*/
 		
 		if (freeIdx < storage.Lower)
 		{
@@ -543,7 +549,13 @@ public:
 				return nullptr;
 			}
 		}
-		
+		// The server accepts connections from 0.3.7 clients.
+		// We can't create more than 1000 objects.
+		/*if (component_.is037CompatModeEnabled() && freeIdx >= OBJECT_POOL_SIZE_037)
+		{
+			return nullptr;
+		}*/
+
 		int objid = storage.claimHint(freeIdx, *this, modelID, position, rotation, drawDist, component_.getDefaultCameraCollision());
 		if (objid < storage.Lower)
 		{

--- a/Server/Components/Objects/objects_impl.hpp
+++ b/Server/Components/Objects/objects_impl.hpp
@@ -353,7 +353,8 @@ public:
 		Object* obj = storage.get(objid);
 		for (IPlayer* player : players->entries())
 		{
-			obj->createForPlayer(*player);
+			if(player.getClientVersion() != ClientVersion::ClientVersion_SAMP_03DL && < freeIdx < OBJECT_POOL_SIZE_037)
+				obj->createForPlayer(*player);
 		}
 
 		return obj;
@@ -555,6 +556,10 @@ public:
 		{
 			return nullptr;
 		}*/
+		if(player_.getClientVersion() != ClientVersion::ClientVersion_SAMP_03DL && freeIdx >= OBJECT_POOL_SIZE_037)
+		{
+			return nullptr;
+		}
 
 		int objid = storage.claimHint(freeIdx, *this, modelID, position, rotation, drawDist, component_.getDefaultCameraCollision());
 		if (objid < storage.Lower)

--- a/Server/Components/Objects/objects_impl.hpp
+++ b/Server/Components/Objects/objects_impl.hpp
@@ -353,7 +353,7 @@ public:
 		Object* obj = storage.get(objid);
 		for (IPlayer* player : players->entries())
 		{
-			if(*player.getClientVersion() != ClientVersion::ClientVersion_SAMP_03DL && < freeIdx < OBJECT_POOL_SIZE_037)
+			if(players->getClientVersion() != ClientVersion::ClientVersion_SAMP_03DL && < freeIdx < OBJECT_POOL_SIZE_037)
 				obj->createForPlayer(*player);
 		}
 

--- a/Server/Components/Objects/objects_impl.hpp
+++ b/Server/Components/Objects/objects_impl.hpp
@@ -330,14 +330,7 @@ public:
 
 			freeIdx = storage.findFreeIndex(freeIdx + 1);
 		}
-
-		// The server accepts connections from 0.3.7 clients.
-		// We can't create more than 1000 objects.
-		if (compatModeEnabled && freeIdx >= OBJECT_POOL_SIZE_037)
-		{
-			return nullptr;
-		}
-
+		
 		if (freeIdx < storage.Lower)
 		{
 			// No free index
@@ -550,14 +543,7 @@ public:
 				return nullptr;
 			}
 		}
-
-		// The server accepts connections from 0.3.7 clients.
-		// We can't create more than 1000 objects.
-		if (component_.is037CompatModeEnabled() && freeIdx >= OBJECT_POOL_SIZE_037)
-		{
-			return nullptr;
-		}
-
+		
 		int objid = storage.claimHint(freeIdx, *this, modelID, position, rotation, drawDist, component_.getDefaultCameraCollision());
 		if (objid < storage.Lower)
 		{

--- a/Server/Components/Objects/objects_impl.hpp
+++ b/Server/Components/Objects/objects_impl.hpp
@@ -353,7 +353,7 @@ public:
 		Object* obj = storage.get(objid);
 		for (IPlayer* player : players->entries())
 		{
-			if(player.getClientVersion() != ClientVersion::ClientVersion_SAMP_03DL && < freeIdx < OBJECT_POOL_SIZE_037)
+			if(*player.getClientVersion() != ClientVersion::ClientVersion_SAMP_03DL && < freeIdx < OBJECT_POOL_SIZE_037)
 				obj->createForPlayer(*player);
 		}
 


### PR DESCRIPTION
I ran several tests, completely removing the limitation and using 037, and making this change that worked well on both the 037 and 03DL.
I also did tests on vehicles, which I was unsuccessful at, but I preferred to keep the objects.