### PR TITLE
improved dialog response checking

### DIFF
--- a/Server/Components/Dialogs/dialog.cpp
+++ b/Server/Components/Dialogs/dialog.cpp
@@ -144,11 +144,16 @@ private:
 		{
 			NetCode::RPC::OnPlayerDialogResponse sendDialogResponse;
 			if (!sendDialogResponse.read(bs))
+			{
 				return false;
+			}
 
 			// If the dialog id doesn't match what the server is expecting, ignore it
 			PlayerDialogData* data = queryExtension<PlayerDialogData>(peer);
 			if (!data || data->getActiveID() == INVALID_DIALOG_ID || data->getActiveID() != sendDialogResponse.ID)
+				return false;
+
+			if(sendDialogResponse.Response < 0 || sendDialogResponse.Response > 1)
 				return false;
 
 			if((data->style_ == DialogStyle_PASSWORD || data->style_ == DialogStyle_INPUT || data->style_ == DialogStyle_MSGBOX) && sendDialogResponse.ListItem != -1)
@@ -158,8 +163,8 @@ private:
 			{
 				unsigned int lines = 0;
 
-				for(unsigned int i = 0 ; i < data->body_.length(); i++)
-					if(data->body_[i] == '\n' && data->body_[i + 1] != '\0')
+				for(unsigned int i = 0 ; i < data->body_.length() - 1; i++)
+					if(data->body_[i] == '\n')
 						lines++;
 				
 				if(data->style_ == DialogStyle_TABLIST_HEADERS && lines > 0)
@@ -175,7 +180,7 @@ private:
 				&PlayerDialogEventHandler::onDialogResponse,
 				peer,
 				sendDialogResponse.ID,
-				static_cast<DialogResponse>(sendDialogResponse.Response % 2),
+				static_cast<DialogResponse>(sendDialogResponse.Response),
 				sendDialogResponse.ListItem,
 				sendDialogResponse.Text);
 

--- a/Server/Components/Dialogs/dialog.cpp
+++ b/Server/Components/Dialogs/dialog.cpp
@@ -144,21 +144,29 @@ private:
 		{
 			NetCode::RPC::OnPlayerDialogResponse sendDialogResponse;
 			if (!sendDialogResponse.read(bs))
-			{
 				return false;
-			}
 
 			// If the dialog id doesn't match what the server is expecting, ignore it
 			PlayerDialogData* data = queryExtension<PlayerDialogData>(peer);
 			if (!data || data->getActiveID() == INVALID_DIALOG_ID || data->getActiveID() != sendDialogResponse.ID)
-			{
 				return false;
-			}
 
-			// If dialog type is one of the lists and list item is invalid, ignore it
-			if (sendDialogResponse.ListItem < 0 && (data->style_ == DialogStyle_LIST || data->style_ == DialogStyle_TABLIST || data->style_ == DialogStyle_TABLIST_HEADERS))
-			{
+			if((data->style_ == DialogStyle_PASSWORD || data->style_ == DialogStyle_INPUT || data->style_ == DialogStyle_MSGBOX) && sendDialogResponse.ListItem != -1)
 				return false;
+
+			if((data->style_ == DialogStyle_LIST || data->style_ == DialogStyle_TABLIST || data->style_ == DialogStyle_TABLIST_HEADERS) && data->body_.length() > 0)
+			{
+				unsigned int lines = 0;
+
+				for(unsigned int i = 0 ; i < data->body_.length(); i++)
+					if(data->body_[i] == '\n' && data->body_[i + 1] != '\0')
+						lines++;
+				
+				if(data->style_ == DialogStyle_TABLIST_HEADERS && lines > 0)
+					lines--;
+
+				if(sendDialogResponse.ListItem < 0 || sendDialogResponse.ListItem > lines)
+					return false;
 			}
 
 			data->activeId = INVALID_DIALOG_ID;

--- a/Server/Components/Dialogs/dialog.cpp
+++ b/Server/Components/Dialogs/dialog.cpp
@@ -175,7 +175,7 @@ private:
 				&PlayerDialogEventHandler::onDialogResponse,
 				peer,
 				sendDialogResponse.ID,
-				static_cast<DialogResponse>(sendDialogResponse.Response),
+				static_cast<DialogResponse>(sendDialogResponse.Response % 2),
 				sendDialogResponse.ListItem,
 				sendDialogResponse.Text);
 


### PR DESCRIPTION
Maded:

- now, when processing a response to a dialogs next types: "DIALOG_STYLE_LIST", "DIALOG_STYLE_TABLIST_HEADERS", "DIALOG_STYLE_TABLIST" the number of lines in the body of the dialogue is counted, and if the "listitem" value that the player sent is more than we counted - such a response is ignored.

- limited the response parametr value from 0 to 1

Feat #866 and #867

P.S: Implemented through a loop, not a "Impl::count", since in this case the loop should be faster