### PR TITLE
Fixed: several connection logic issues

### DIFF
--- a/Server/Components/LegacyNetwork/legacy_network_impl.cpp
+++ b/Server/Components/LegacyNetwork/legacy_network_impl.cpp
@@ -360,11 +360,7 @@ IPlayer* RakNetLegacyNetwork::OnPeerConnect(RakNet::RPCParameters* rpcParams, bo
 			RakNet::BitStream bss;
 			bss.Write(uint8_t(newConnectionResult.first));
 			rakNetServer.RPC(130, &bss, RakNet::HIGH_PRIORITY, RakNet::UNRELIABLE, 0, rid, false, false, RakNet::UNASSIGNED_NETWORK_ID, nullptr);
-
-			if (newConnectionResult.first != NewConnectionResult_VersionMismatch)
-			{
-				rakNetServer.Kick(rid);
-			}
+			rakNetServer.Kick(rid);
 		}
 		return nullptr;
 	}
@@ -424,7 +420,6 @@ void RakNetLegacyNetwork::OnPlayerConnect(RakNet::RPCParameters* rpcParams, void
 				return;
 			}
 
-			remoteSystem->isLogon = true;
 			IPlayer* newPeer = network->OnPeerConnect(rpcParams, false, serial, playerConnectRPC.VersionNumber, playerConnectRPC.VersionString, playerConnectRPC.ChallengeResponse, playerConnectRPC.Name, playerConnectRPC.IsUsingOfficialClient);
 			if (newPeer)
 			{
@@ -450,19 +445,11 @@ void RakNetLegacyNetwork::OnPlayerConnect(RakNet::RPCParameters* rpcParams, void
 				}
 
 				network->networkEventDispatcher.dispatch(&NetworkEventHandler::onPeerConnect, *newPeer);
-
 				network->playerRemoteSystem[newPeer->getID()] = remoteSystem;
-				return;
+				remoteSystem->isLogon = true;
 			}
 		}
-		else
-		{
-			network->rakNetServer.Kick(rpcParams->sender);
-		}
-		return;
 	}
-
-	network->rakNetServer.Kick(rpcParams->sender);
 }
 
 void RakNetLegacyNetwork::OnNPCConnect(RakNet::RPCParameters* rpcParams, void* extra)
@@ -481,7 +468,6 @@ void RakNetLegacyNetwork::OnNPCConnect(RakNet::RPCParameters* rpcParams, void* e
 		NetCode::RPC::NPCConnect NPCConnectRPC;
 		if (NPCConnectRPC.read(bs))
 		{
-			remoteSystem->isLogon = true;
 			IPlayer* newPeer = network->OnPeerConnect(rpcParams, true, "", NPCConnectRPC.VersionNumber, "npc", NPCConnectRPC.ChallengeResponse, NPCConnectRPC.Name);
 			if (newPeer)
 			{
@@ -507,12 +493,10 @@ void RakNetLegacyNetwork::OnNPCConnect(RakNet::RPCParameters* rpcParams, void* e
 				}
 
 				network->networkEventDispatcher.dispatch(&NetworkEventHandler::onPeerConnect, *newPeer);
-				return;
+				remoteSystem->isLogon = true;
 			}
 		}
 	}
-
-	network->rakNetServer.Kick(rpcParams->sender);
 }
 
 void RakNetLegacyNetwork::OnRakNetDisconnect(RakNet::PlayerIndex rid, PeerDisconnectReason reason)

--- a/Server/Components/LegacyNetwork/legacy_network_impl.cpp
+++ b/Server/Components/LegacyNetwork/legacy_network_impl.cpp
@@ -384,7 +384,7 @@ void RakNetLegacyNetwork::OnPlayerConnect(RakNet::RPCParameters* rpcParams, void
 		network->rakNetServer.Kick(rpcParams->sender);
 		return;
 	}
-	
+
 	NetworkBitStream bs = GetBitStream(*rpcParams);
 	NetCode::RPC::PlayerConnect playerConnectRPC;
 	if (!playerConnectRPC.read(bs))


### PR DESCRIPTION
1. Clients weren't kicked if the client version doesn't match the server version.
2. Clients were flagged as logged in to the game regardless of the result of OnPeerConnect, meaning they wouldn't be dropped in the event of a failure.