### PR TITLE
Handle internal immediate forced disconnects

### DIFF
--- a/Server/Components/LegacyNetwork/legacy_network_impl.cpp
+++ b/Server/Components/LegacyNetwork/legacy_network_impl.cpp
@@ -529,6 +529,12 @@ void RakNetLegacyNetwork::OnRakNetDisconnect(RakNet::PlayerIndex rid, PeerDiscon
 	networkEventDispatcher.dispatch(&NetworkEventHandler::onPeerDisconnect, *player, reason);
 }
 
+void RakNetLegacyNetwork::OnCloseConnection(RakNet::RakPeerInterface* peer, RakNet::PlayerID playerId)
+{
+	auto playerIndex = peer->GetIndexFromPlayerID(playerId);
+	OnRakNetDisconnect(playerIndex, PeerDisconnectReason_Kicked);
+}
+
 template <size_t ID>
 void RakNetLegacyNetwork::RPCHook(RakNet::RPCParameters* rpcParams, void* extra)
 {
@@ -870,6 +876,8 @@ void RakNetLegacyNetwork::start()
 			const String get = "https://api.open.mp/0.3.7/announce/" + std::to_string(port);
 			core->requestHTTP4(new AnnounceHTTPResponseHandler(core), HTTPRequestType::HTTPRequestType_Get, get.data());
 		}
+
+		rakNetServer.AttachPlugin(this);
 	}
 
 	rakNetServer.StartOccasionalPing();

--- a/Server/Components/LegacyNetwork/legacy_network_impl.hpp
+++ b/Server/Components/LegacyNetwork/legacy_network_impl.hpp
@@ -19,6 +19,7 @@
 #include <raknet/GetTime.h>
 #include <raknet/RakNetworkFactory.h>
 #include <raknet/RakServerInterface.h>
+#include <raknet/PluginInterface.h>
 #include <raknet/StringCompressor.h>
 
 using namespace Impl;
@@ -31,7 +32,7 @@ static const StaticArray<StringView, 2> ProtectedRules = {
 
 class Core;
 
-class RakNetLegacyNetwork final : public Network, public CoreEventHandler, public PlayerConnectEventHandler, public PlayerChangeEventHandler, public INetworkQueryExtension
+class RakNetLegacyNetwork final : public Network, public CoreEventHandler, public PlayerConnectEventHandler, public PlayerChangeEventHandler, public INetworkQueryExtension, public RakNet::PluginInterface
 {
 private:
 	ICore* core = nullptr;
@@ -290,6 +291,7 @@ public:
 	void start();
 
 	void OnRakNetDisconnect(RakNet::PlayerIndex rid, PeerDisconnectReason reason);
+	void OnCloseConnection(RakNet::RakPeerInterface* peer, RakNet::PlayerID playerId) override;
 
 	void onPlayerScoreChange(IPlayer& player, int score) override
 	{


### PR DESCRIPTION
This PR is basically doing what https://github.com/openmultiplayer/RakNet/pull/21 does but properly by handling forced closed connections/disconnects

Quoted explanation from the said PR:
> If a player exceeds a network limit (e.g. messageholelimit), the player's IP is banned and the connection is immediately closed by RakNet internally. The open.mp server is by design not notified of connections closed internally by RakNet. This causes three issues. First, the player concerned will remain connected in open.mp as a zombie player. Second, once all player IDs are taken, new players are assigned player ID -1. Third, due to missing array boundary checks in the open.mp server at several places, the server will crash when trying to access an array at index -1. This commit fixes all issues by banning the IP only, which results in a connection time out, of which the open.mp server is notified, which deletes the player accordingly. 