### PR TITLE
Fix GetGameText native giving incorrect/corrupt values

### DIFF
--- a/Server/Components/Fixes/fixes.cpp
+++ b/Server/Components/Fixes/fixes.cpp
@@ -574,7 +574,7 @@ public:
 	{
 		if (gts_[style] && gtTimers_[style])
 		{
-			message = String(gts_[style]->getText());
+			message = gts_[style]->getText();
 			time = gtTimers_[style]->interval();
 			remaining = gtTimers_[style]->remaining();
 			return true;

--- a/Server/Components/Pawn/Scripting/Player/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Player/Natives.cpp
@@ -964,7 +964,7 @@ SCRIPT_API(HasGameText, bool(IPlayer& player, int style))
 	return player.hasGameText(style);
 }
 
-SCRIPT_API(GetGameText, bool(IPlayer& player, int style, OutputOnlyString& message, int time, int remaining))
+SCRIPT_API(GetGameText, bool(IPlayer& player, int style, OutputOnlyString& message, int& time, int& remaining))
 {
 	Milliseconds mt;
 	Milliseconds mr;


### PR DESCRIPTION
- native `GetGameText` was giving incorrect values, the last two parameters of this native (time and remaining) wasn't passed as reference so the value were not updated.
- The message value was getting deallocated in the `PlayerFixesData::gameText` as it was creating an unnecessary local copy

This PR fixes these problems.