### PR TITLE
Stop broadcasting spectators sync data.

### DIFF
--- a/Server/Components/Pawn/timers.hpp
+++ b/Server/Components/Pawn/timers.hpp
@@ -114,7 +114,8 @@ struct PawnTimerHandler final : TimerTimeOutHandler, PoolIDProvider
 			if ((err = amx_Allot(amx, data.size(), &out, &in)) != AMX_ERR_NONE)
 			{
 				PawnManager::Get()->core->logLn(LogLevel::Error, "SetTimer(Ex): Not enough space in heap for %.*s timer: %s", PRINT_VIEW(callback), aux_StrError(err));
-				amx_RaiseError(amx, err);
+				// Raising an error here will cause the entire mode to stop executing in some cases.
+				// amx_RaiseError(amx, err);
 				return;
 			}
 			if (data.data())

--- a/Server/Source/player_pool.hpp
+++ b/Server/Source/player_pool.hpp
@@ -2116,82 +2116,87 @@ struct PlayerPool final : public IPlayerPool, public NetworkEventHandler, public
 				continue;
 			}
 
-			switch (player->primarySyncUpdateType_)
+			if (!player->spectateData_.spectating)
 			{
-			case PrimarySyncUpdateType::OnFoot:
-			{
-				if (!player->controllable_)
+				switch (player->primarySyncUpdateType_)
 				{
-					player->footSync_.Keys = 0;
-					player->footSync_.UpDown = 0;
-					player->footSync_.LeftRight = 0;
-				}
-
-				// Setting player's special action to enter vehicle
-				if (player->ghostMode_)
+				case PrimarySyncUpdateType::OnFoot:
 				{
-					player->footSync_.SpecialAction = SpecialAction_EnterVehicle;
-				}
-
-				PacketHelper::broadcastSyncPacket(player->footSync_, *player);
-				break;
-			}
-			case PrimarySyncUpdateType::Driver:
-			{
-				if (!player->controllable_)
-				{
-					player->vehicleSync_.Keys = 0;
-					player->vehicleSync_.UpDown = 0;
-					player->vehicleSync_.LeftRight = 0;
-				}
-
-				PacketHelper::broadcastSyncPacket(player->vehicleSync_, *player);
-				break;
-			}
-			case PrimarySyncUpdateType::Passenger:
-			{
-				if (!player->controllable_)
-				{
-					player->passengerSync_.Keys = 0;
-					player->passengerSync_.UpDown = 0;
-					player->passengerSync_.LeftRight = 0;
-				}
-
-				uint16_t keys = player->passengerSync_.Keys;
-				if (player->passengerSync_.WeaponID == 43 /* camera */)
-				{
-					player->passengerSync_.Keys &= 0xFB;
-				}
-				PacketHelper::broadcastSyncPacket(player->passengerSync_, *player);
-				player->passengerSync_.Keys = keys;
-
-				break;
-			}
-			default:
-				break;
-			}
-			player->primarySyncUpdateType_ = PrimarySyncUpdateType::None;
-
-			if (player->secondarySyncUpdateType_ & SecondarySyncUpdateType_Aim)
-			{
-				PacketHelper::broadcastSyncPacket(player->aimSync_, *player);
-			}
-			if (player->secondarySyncUpdateType_ & SecondarySyncUpdateType_Trailer)
-			{
-				PacketHelper::broadcastSyncPacket(player->trailerSync_, *player);
-			}
-			if (player->secondarySyncUpdateType_ & SecondarySyncUpdateType_Unoccupied)
-			{
-				if (vehiclesComponent)
-				{
-					IVehicle* vehicle = vehiclesComponent->get(player->unoccupiedSync_.VehicleID);
-					if (vehicle)
+					if (!player->controllable_)
 					{
-						PacketHelper::broadcastToSome(player->unoccupiedSync_, vehicle->streamedForPlayers(), player);
+						player->footSync_.Keys = 0;
+						player->footSync_.UpDown = 0;
+						player->footSync_.LeftRight = 0;
+					}
+
+					// Setting player's special action to enter vehicle
+					if (player->ghostMode_)
+					{
+						player->footSync_.SpecialAction = SpecialAction_EnterVehicle;
+					}
+
+					PacketHelper::broadcastSyncPacket(player->footSync_, *player);
+					break;
+				}
+				case PrimarySyncUpdateType::Driver:
+				{
+					if (!player->controllable_)
+					{
+						player->vehicleSync_.Keys = 0;
+						player->vehicleSync_.UpDown = 0;
+						player->vehicleSync_.LeftRight = 0;
+					}
+
+					PacketHelper::broadcastSyncPacket(player->vehicleSync_, *player);
+					break;
+				}
+				case PrimarySyncUpdateType::Passenger:
+				{
+					if (!player->controllable_)
+					{
+						player->passengerSync_.Keys = 0;
+						player->passengerSync_.UpDown = 0;
+						player->passengerSync_.LeftRight = 0;
+					}
+
+					uint16_t keys = player->passengerSync_.Keys;
+					if (player->passengerSync_.WeaponID == 43 /* camera */)
+					{
+						player->passengerSync_.Keys &= 0xFB;
+					}
+					PacketHelper::broadcastSyncPacket(player->passengerSync_, *player);
+					player->passengerSync_.Keys = keys;
+
+					break;
+				}
+				default:
+					break;
+				}
+				player->primarySyncUpdateType_ = PrimarySyncUpdateType::None;
+
+				if (player->secondarySyncUpdateType_ & SecondarySyncUpdateType_Aim)
+				{
+					PacketHelper::broadcastSyncPacket(player->aimSync_, *player);
+				}
+				if (player->secondarySyncUpdateType_ & SecondarySyncUpdateType_Trailer)
+				{
+					PacketHelper::broadcastSyncPacket(player->trailerSync_, *player);
+				}
+				if (player->secondarySyncUpdateType_ & SecondarySyncUpdateType_Unoccupied)
+				{
+					if (vehiclesComponent)
+					{
+						IVehicle* vehicle = vehiclesComponent->get(player->unoccupiedSync_.VehicleID);
+						if (vehicle)
+						{
+							PacketHelper::broadcastToSome(player->unoccupiedSync_, vehicle->streamedForPlayers(), player);
+						}
 					}
 				}
+
+				player->secondarySyncUpdateType_ = 0;
 			}
-			player->secondarySyncUpdateType_ = 0;
+
 			++it;
 		}
 


### PR DESCRIPTION
1. First commit removes a call to amx_RaiseError while attempting to call a timer code if there's not enough memory to continue. 
Raising errors in this state seems to break the whole current script.
It's samething we've dealt with in beta (https://github.com/openmultiplayer/open.mp/commit/75619d0938c524fc9ffbc0e3eb4f5e5e5d1fd833) when we removed 1 call but forgot this one.

2. Check if player is in spectator mode before broadcasting any sync updates. Some bad actors are using sync updates (prob camera sync or idk - didn't bother to actually check) to obtain a list of spectators. This will solve that.