### PR TITLE
Fix locale switch for names with non-ascii characters

### DIFF
--- a/Server/Source/core_impl.hpp
+++ b/Server/Source/core_impl.hpp
@@ -1778,7 +1778,7 @@ public:
 #ifdef BUILD_WINDOWS
 		_lock_locales();
 		UINT oldCP = 0;
-		char oldLocale[64] = { 0 };
+		wchar_t oldLocale[64] = { 0 };
 		bool oldLocaleSaved = false;
 		if (utf8)
 		{
@@ -1786,10 +1786,10 @@ public:
 			SetConsoleOutputCP(CP_UTF8);
 
 			/* Getting current locale */
-			const char* old_locale_ptr = std::setlocale(LC_CTYPE, nullptr);
+			const wchar_t* old_locale_ptr = _wsetlocale(LC_CTYPE, nullptr);
 			if (old_locale_ptr != nullptr)
 			{
-				strcpy_s(oldLocale, old_locale_ptr);
+				wcscpy_s(oldLocale, old_locale_ptr);
 				oldLocaleSaved = true;
 
 				std::setlocale(LC_CTYPE, ".UTF-8");
@@ -1867,7 +1867,7 @@ public:
 		{
 			if (oldLocaleSaved)
 			{
-				std::setlocale(LC_CTYPE, oldLocale);
+				_wsetlocale(LC_CTYPE, oldLocale);
 			}
 			SetConsoleOutputCP(oldCP);
 		}


### PR DESCRIPTION
We previously had issues with people running omp-server executable and it was getting closed right after "Loaded X components from XXX"
Which was a log message sent using `printLnU8`. Apparently for locales containing non-ascii characters, after changing locale to utf8, `std::setlocale` fails to work properly, probably due to encoding being different? and requiring a utf8 version when trying to reset it? but using a wide char version of the function, it works fine (since wide chars can be used to store non-ascii values)

### References on discord:
user `ꜱɪᴄᴀʀɪᴏ` reporting it's not working for him, and apparently not for two other users as well
https://discord.com/channels/231799104731217931/966398440051445790/1231157837363806349

His video of showing how it looks:
https://github.com/user-attachments/assets/025b3de3-7175-401e-bc3d-056cf87748a8

We changed `printLnU8` to `printLn` and then it was working fine:
https://github.com/openmultiplayer/open.mp/actions/runs/8764920431



