### PR TITLE
Network fixes

### DIFF
--- a/Server/Components/LegacyNetwork/legacy_network_impl.cpp
+++ b/Server/Components/LegacyNetwork/legacy_network_impl.cpp
@@ -891,6 +891,19 @@ void RakNetLegacyNetwork::onTick(Microseconds elapsed, TimePoint now)
 		}
 
 		IPlayer* player = playerFromRakIndex[pkt->playerIndex];
+
+		// We shouldn't be needing this, it's only here IF somehow this is happening again
+		// So users can report it to us
+		if (player && player->getID() == -1)
+		{
+			rakNetServer.Kick(pkt->playerId);
+			playerFromRakIndex[pkt->playerIndex] = nullptr;
+			core->logLn(LogLevel::Warning, "RakNet player %d with open.mp player pool id -1  was found and deleted. Packet ID: %d", pkt->playerIndex, pkt->data[0]);
+			core->logLn(LogLevel::Warning, "Please contact us by creating an issue in our repository at https://github.com/openmultiplayer/open.mp");
+			rakNetServer.DeallocatePacket(pkt);
+			continue;
+		}
+
 		if (player)
 		{
 			NetworkBitStream bs(pkt->data, pkt->length, false);

--- a/Server/Components/LegacyNetwork/legacy_network_impl.hpp
+++ b/Server/Components/LegacyNetwork/legacy_network_impl.hpp
@@ -86,6 +86,7 @@ public:
 		{
 			playerFromRakIndex[playerIndex] = nullptr;
 		}
+		playerRemoteSystem[peer.getID()] = nullptr;
 		rakNetServer.Kick(rid);
 	}
 


### PR DESCRIPTION
There has been a lot of crashes happening due to double free mostly in `InternalPacketPool::ClearPool` and `ReliablityLayer::FreeThreadedMemory` calls due to mishandling `InternalPacket` instances for allocation and deallocation of them.

This PR should fix this problem and provide a stable connection