### PR TITLE
Fix SetPlayerSkin (add custom skin without DL client) for mobile clients

### DIFF
--- a/Shared/NetCode/core.hpp
+++ b/Shared/NetCode/core.hpp
@@ -748,7 +748,9 @@ namespace RPC
 
 			bs.writeUINT16(PlayerID);
 			bs.writeUINT32(Skin);
-			bs.writeUINT32(CustomSkin);
+
+			if (isDL)
+				bs.writeUINT32(CustomSkin);
 		}
 	};
 


### PR DESCRIPTION
Mobile clients check RPC SetPlayerSkin for valid... Addedable custom skin not valid in 0.3.7 clients (mobile)