### PR TITLE
More validity checks for vehicles (mainly trailers)

### DIFF
--- a/Server/Components/Vehicles/vehicle.cpp
+++ b/Server/Components/Vehicles/vehicle.cpp
@@ -159,7 +159,7 @@ void Vehicle::streamOutForClient(IPlayer& player)
 
 bool Vehicle::updateFromDriverSync(const VehicleDriverSyncPacket& vehicleSync, IPlayer& player)
 {
-	if (respawning)
+	if (respawning || !streamedFor_.valid(player.getID()))
 	{
 		return false;
 	}
@@ -381,6 +381,11 @@ bool Vehicle::updateFromTrailerSync(const VehicleTrailerSyncPacket& trailerSync,
 
 bool Vehicle::updateFromPassengerSync(const VehiclePassengerSyncPacket& passengerSync, IPlayer& player)
 {
+	if (!streamedFor_.valid(player.getID()))
+	{
+		return false;
+	}
+
 	PlayerVehicleData* data = queryExtension<PlayerVehicleData>(player);
 	if (!data)
 	{

--- a/Server/Components/Vehicles/vehicle.cpp
+++ b/Server/Components/Vehicles/vehicle.cpp
@@ -233,7 +233,15 @@ bool Vehicle::updateFromDriverSync(const VehicleDriverSyncPacket& vehicleSync, I
 			trailer = static_cast<Vehicle*>(pool->get(vehicleSync.TrailerID));
 			if (trailer)
 			{
-				trailer->cab = this;
+				const bool isStreamedIn = trailer->isStreamedInForPlayer(player);
+				if (!isStreamedIn)
+				{
+					trailer = nullptr;
+				}
+				else
+				{
+					trailer->cab = this;
+				}
 			}
 		}
 	}

--- a/Server/Components/Vehicles/vehicle.cpp
+++ b/Server/Components/Vehicles/vehicle.cpp
@@ -381,11 +381,6 @@ bool Vehicle::updateFromTrailerSync(const VehicleTrailerSyncPacket& trailerSync,
 
 bool Vehicle::updateFromPassengerSync(const VehiclePassengerSyncPacket& passengerSync, IPlayer& player)
 {
-	if (!streamedFor_.valid(player.getID()))
-	{
-		return false;
-	}
-
 	PlayerVehicleData* data = queryExtension<PlayerVehicleData>(player);
 	if (!data)
 	{

--- a/Server/Source/player_pool.hpp
+++ b/Server/Source/player_pool.hpp
@@ -1532,6 +1532,11 @@ struct PlayerPool final : public IPlayerPool, public NetworkEventHandler, public
 				return false;
 			}
 
+			if (trailerSync.TurnVelocity.x < -1.0f || trailerSync.TurnVelocity.x > 1.0f || trailerSync.TurnVelocity.y < -1.0f || trailerSync.TurnVelocity.y > 1.0f || trailerSync.TurnVelocity.z < -1.0f || trailerSync.TurnVelocity.z > 1.0f)
+			{
+				return false;
+			}
+
 			IVehicle* vehiclePtr = self.vehiclesComponent->get(trailerSync.VehicleID);
 			if (!vehiclePtr)
 			{


### PR DESCRIPTION
1. Fix [#984](https://github.com/openmultiplayer/open.mp/issues/984) by adding a check `isStreamedInForPlayer` when player reported a new trailer in driver sync.
2. Add stream checks for the whole driver sync, since it also can be spoofed on non-streamed vehicles which is not possible to do for fair players. I tested it with different cases including moving a car out of a stream zone by teleporting it somewhere far and so on. Not a single packet of those driver sync was called with `IsVehicleStreamedIn` at false value.
3. Check turn (angular) velocity for validity in trailer sync just like with unoccupied sync.