### PR TITLE
Main script config fixes

### DIFF
--- a/Server/Components/LegacyConfig/config_main.cpp
+++ b/Server/Components/LegacyConfig/config_main.cpp
@@ -487,17 +487,15 @@ private:
 					processFallback(logger, config, typeIt->second, name, line.substr(idx + 1));
 				}
 			}
-			size_t gmcount = 0;
 			DynamicArray<StringView> list;
 			for (int i = 0; i < gamemodes_.size(); ++i)
 			{
 				if (gamemodes_[i] != "")
 				{
-					++gmcount;
 					list.emplace_back(gamemodes_[i]);
 				}
 			}
-			if (gmcount != 0)
+			if (!list.empty())
 			{
 				config.setStrings("pawn.main_scripts", list);
 			}

--- a/Server/Components/Pawn/Manager/Manager.cpp
+++ b/Server/Components/Pawn/Manager/Manager.cpp
@@ -14,6 +14,7 @@
 #include "Manager.hpp"
 #include "../PluginManager/PluginManager.hpp"
 #include "../utils.hpp"
+#include <utils.hpp>
 
 #ifdef WIN32
 #include <Windows.h>
@@ -416,25 +417,26 @@ bool PawnManager::Load(DynamicArray<StringView> const& mainScripts)
 	}
 	gamemodes_.clear();
 	gamemodeIndex_ = 0;
-	for (auto const& i : mainScripts)
+	for (StringView script : mainScripts)
 	{
+		script = trim(script);
 		// Split the mode name and count.
-		auto space = i.find_last_of(' ');
+		auto space = script.find_last_of(' ');
 		if (space == std::string::npos)
 		{
 			repeats_.push_back(1);
-			gamemodes_.push_back(String(i));
+			gamemodes_.push_back(String(script));
 		}
 		else
 		{
 			int count = 0;
-			auto conv = std::from_chars(i.data() + space + 1, i.data() + i.size(), count, 10);
+			auto conv = std::from_chars(script.data() + space + 1, script.data() + script.size(), count, 10);
 			if (conv.ec == std::errc::invalid_argument || conv.ec == std::errc::result_out_of_range || count < 1)
 			{
 				count = 1;
 			}
 			repeats_.push_back(count);
-			gamemodes_.push_back(String(i.substr(0, space)));
+			gamemodes_.push_back(String(trim(script.substr(0, space))));
 		}
 	}
 	gamemodeRepeat_ = repeats_[0];

--- a/Server/Source/core_impl.hpp
+++ b/Server/Source/core_impl.hpp
@@ -553,11 +553,12 @@ public:
 
 	void setStrings(StringView key, Span<const StringView> value) override
 	{
-		auto& vec = processed[String(key)].emplace<DynamicArray<String>>();
+		DynamicArray<String> newStrings;
 		for (const StringView v : value)
 		{
-			vec.emplace_back(String(v));
+			newStrings.emplace_back(String(v));
 		}
+		processed[String(key)].emplace<DynamicArray<String>>(std::move(newStrings));
 	}
 
 	void addBan(const BanEntry& entry) override


### PR DESCRIPTION
* Fix general issue where setStrings could overwrite getStrings data before copying it, resulting in corruption; noticed when loading main scripts from file while having --script argument
* Properly trim main scripts with repeat count

Fixes #938 