### PR TITLE
Fix issues with reallocating bitstreams in sendRPC/sendPacket

### DIFF
--- a/Server/Components/LegacyNetwork/legacy_network_impl.cpp
+++ b/Server/Components/LegacyNetwork/legacy_network_impl.cpp
@@ -297,15 +297,14 @@ RakNetLegacyNetwork::~RakNetLegacyNetwork()
 
 static NetworkBitStream GetBitStream(RakNet::RPCParameters& rpcParams)
 {
-	unsigned int
+	const unsigned int
 		bits
 		= rpcParams.numberOfBitsOfData;
 	if (bits == 0)
 		return NetworkBitStream();
-	unsigned int
-		bytes
-		= (bits - 1) / 8 + 1;
-	return NetworkBitStream(rpcParams.input, bytes, false);
+	NetworkBitStream bs(rpcParams.input, bitsToBytes(bits), false /* copyData */);
+	bs.SetWriteOffset(bits);
+	return bs;
 }
 
 enum LegacyClientVersion
@@ -906,7 +905,9 @@ void RakNetLegacyNetwork::onTick(Microseconds elapsed, TimePoint now)
 
 		if (player)
 		{
-			NetworkBitStream bs(pkt->data, pkt->length, false);
+			const unsigned int bits = pkt->bitSize;
+			NetworkBitStream bs(pkt->data, bitsToBytes(bits), false);
+			bs.SetWriteOffset(bits);
 			uint8_t type;
 			if (bs.readUINT8(type))
 			{

--- a/Server/Components/LegacyNetwork/legacy_network_impl.hpp
+++ b/Server/Components/LegacyNetwork/legacy_network_impl.hpp
@@ -92,11 +92,9 @@ public:
 
 	bool broadcastPacket(Span<uint8_t> data, int channel, const IPlayer* exceptPeer, bool dispatchEvents) override
 	{
-		// Don't use constructor because it takes bytes; we want bits
-		NetworkBitStream bs;
-		bs.SetData(data.data());
+		// We want exact bits - set the write offset with bit granularity
+		NetworkBitStream bs(data.data(), bitsToBytes(data.size()), false /* copyData */);
 		bs.SetWriteOffset(data.size());
-		bs.SetReadOffset(0);
 
 		if (dispatchEvents)
 		{
@@ -147,11 +145,9 @@ public:
 			return false;
 		}
 
-		// Don't use constructor because it takes bytes; we want bits
-		NetworkBitStream bs;
-		bs.SetData(data.data());
+		// We want exact bits - set the write offset with bit granularity
+		NetworkBitStream bs(data.data(), bitsToBytes(data.size()), false /* copyData */);
 		bs.SetWriteOffset(data.size());
-		bs.SetReadOffset(0);
 
 		if (dispatchEvents)
 		{
@@ -191,11 +187,9 @@ public:
 			return false;
 		}
 
-		// Don't use constructor because it takes bytes; we want bits
-		NetworkBitStream bs;
-		bs.SetData(data.data());
+		// We want exact bits - set the write offset with bit granularity
+		NetworkBitStream bs(data.data(), bitsToBytes(data.size()), false /* copyData */);
 		bs.SetWriteOffset(data.size());
-		bs.SetReadOffset(0);
 
 		if (dispatchEvents)
 		{
@@ -247,11 +241,9 @@ public:
 			return false;
 		}
 
-		// Don't use constructor because it takes bytes; we want bits
-		NetworkBitStream bs;
-		bs.SetData(data.data());
+		// We want exact bits - set the write offset with bit granularity
+		NetworkBitStream bs(data.data(), bitsToBytes(data.size()), false /* copyData */);
 		bs.SetWriteOffset(data.size());
-		bs.SetReadOffset(0);
 
 		if (dispatchEvents)
 		{


### PR DESCRIPTION
Fix issues where reallocating bitstreams in sendRPC/sendPacket hooks didn't copy the whole data because of incorrectly constructing the stream's numBitsAllocated field