### PR TITLE
Fix for non-bullet guns returned as 0 in weapon data

### DIFF
--- a/Server/Source/player_impl.hpp
+++ b/Server/Source/player_impl.hpp
@@ -1359,10 +1359,6 @@ removeWeapon_has_weapon:
 			return ret;
 		}
 		WeaponSlotData ret = weapons_[slot];
-		if (ret.ammo == 0)
-		{
-			ret.id = 0;
-		}
 		return ret;
 	}
 


### PR DESCRIPTION
This pretty simply fixes an issue described in #1008 by removing the whole check which was the cause of a problem with GetPlayerWeaponData, when player got some non-bullet (e.g. melee, gift or special weapons) with 0 ammo and it still was in his hands, but after switching weapons back and forth, GetPlayerWeaponData has suddenly start returning 0 as weaponid in its slot which is wrong.

A bit more complicated solution with keeping the initial point of this check would be to add the extra condition like "do the clearing of both weapon and ammo in the slot only if this type of weapon (generally) has ammo but now a player has it 0". After some time I consider this whole check not so crucial, because an "issue" it's aimed to fix doesn't even seem as a real one, and the way of fixing is strange since it doesn't change anything until scrolling the weapons. So, I decided to fix it with this way provided, just by removing it completely.