### PR TITLE
Fix: Avoid a update unstreamed cars by passenger sync

### DIFF
--- a/Server/Source/player_pool.hpp
+++ b/Server/Source/player_pool.hpp
@@ -1376,6 +1376,11 @@ struct PlayerPool final : public IPlayerPool, public NetworkEventHandler, public
 				return false;
 			}
 
+		    if (!vehiclePtr->isStreamedInForPlayer(peer))
+		    {
+		        return false;
+		    }
+
 			auto slot = WeaponSlotData(passengerSync.WeaponID).slot();
 			if (slot == INVALID_WEAPON_SLOT)
 			{


### PR DESCRIPTION
Fix: Avoid a update unstreamed cars by passenger sync

This patch fixes cheat ability to update by passenger sync to unstreamed cars for player. Old SA:MP bug..