### PR TITLE
Fix: Avoid a update unstreamed cars by passenger sync

### DIFF
--- a/Server/Source/player_pool.hpp
+++ b/Server/Source/player_pool.hpp
@@ -1386,7 +1386,7 @@ struct PlayerPool final : public IPlayerPool, public NetworkEventHandler, public
 			IVehicle& vehicle = *lock.entry;
 			Player& player = static_cast<Player&>(peer);
 
-			if (vehicle.isRespawning())
+			if (vehicle.isRespawning() || !vehicle.isStreamedInForPlayer(player))
 				return false;
 
 			const bool vehicleOk = vehicle.updateFromPassengerSync(passengerSync, peer);


### PR DESCRIPTION
Fix: Avoid a update unstreamed cars by passenger sync

This patch fixes cheat ability to update by passenger sync to unstreamed cars for player. Old SA:MP bug..