### PR TITLE
Pack Vehicle and StreamInVehicle more tightly

### DIFF
--- a/Server/Components/Vehicles/vehicle.hpp
+++ b/Server/Components/Vehicles/vehicle.hpp
@@ -48,14 +48,15 @@ private:
 	uint8_t landingGear = 1;
 	bool respawning = false;
 	bool detaching = false;
+	bool beenOccupied = false;
 	FlatHashSet<IPlayer*> passengers;
 	HybridString<16> numberPlate = StringView("XYZSR998");
 	uint8_t objective;
 	uint8_t doorsLocked;
+	uint8_t sirenState = 0;
 	VehicleDeathData deathData;
 	TimePoint timeOfSpawn;
 	TimePoint lastOccupiedChange;
-	bool beenOccupied = false;
 	Vector3 velocity = Vector3(0.0f, 0.0f, 0.0f);
 	Vector3 angularVelocity = Vector3(0.0f, 0.0f, 0.0f);
 	TimePoint trailerUpdateTime;
@@ -63,7 +64,6 @@ private:
 	Vehicle* cab = nullptr;
 	StaticArray<IVehicle*, MAX_VEHICLE_CARRIAGES> carriages;
 	VehicleParams params;
-	uint8_t sirenState = 0;
 	uint32_t hydraThrustAngle = 0;
 	float trainSpeed = 0.0f;
 	int lastDriverPoolID = INVALID_PLAYER_ID;

--- a/Shared/NetCode/vehicle.hpp
+++ b/Shared/NetCode/vehicle.hpp
@@ -111,15 +111,15 @@ namespace RPC
 		float Angle;
 		uint8_t Colour1;
 		uint8_t Colour2;
-		float Health;
 		uint8_t Interior;
+		uint8_t Paintjob;
+		float Health;
 		uint32_t DoorDamage;
 		uint32_t PanelDamage;
 		uint8_t LightDamage;
 		uint8_t TyreDamage;
 		uint8_t Siren;
 		StaticArray<int, MAX_VEHICLE_COMPONENT_SLOT_IN_RPC> Mods;
-		uint8_t Paintjob;
 		int32_t BodyColour1;
 		int32_t BodyColour2;
 


### PR DESCRIPTION
Minor size optimizations
Pack Vehicle and StreamInVehicle more tightly
Size decrease: for Vehicle from 480 bytes to 464 bytes, for StreamInVehicle from 116 bytes to 108 bytes
May be useful for future development, to avoid crossing alignment boundary
No functional changes whatsover