### PR TITLE
Return string length for some natives

### DIFF
--- a/Server/Components/Pawn/Scripting/Core/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Core/Natives.cpp
@@ -598,10 +598,10 @@ SCRIPT_API(GetServerVarAsString, int(std::string const& cvar, OutputOnlyString& 
 	return getConfigOptionAsString(cvar, buffer);
 }
 
-SCRIPT_API(GetWeaponName, bool(int weaponid, OutputOnlyString& weapon))
+SCRIPT_API(GetWeaponName, int(int weaponid, OutputOnlyString& weapon))
 {
 	weapon = PawnManager::Get()->core->getWeaponName(PlayerWeapon(weaponid));
-	return true;
+	return std::get<StringView>(weapon).length();
 }
 
 SCRIPT_API(LimitGlobalChatRadius, bool(float chatRadius))
@@ -642,7 +642,7 @@ SCRIPT_API(NetStats_GetConnectedTime, int(IPlayer& player))
 	return stats.connectionElapsedTime;
 }
 
-SCRIPT_API(NetStats_GetIpPort, bool(IPlayer& player, OutputOnlyString& output))
+SCRIPT_API_FAILRET(NetStats_GetIpPort, -1, int(IPlayer& player, OutputOnlyString& output))
 {
 	PeerNetworkData data = player.getNetworkData();
 	PeerAddress::AddressString addressString;
@@ -653,9 +653,9 @@ SCRIPT_API(NetStats_GetIpPort, bool(IPlayer& player, OutputOnlyString& output))
 		ip_port += std::to_string(data.networkID.port);
 		// Scope-allocated string, copy it
 		output = ip_port;
-		return true;
+		return std::get<String>(output).length();
 	}
-	return false;
+	return FailRet;
 }
 
 SCRIPT_API(NetStats_MessagesReceived, int(IPlayer& player))

--- a/Server/Components/Pawn/Scripting/Variable/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Variable/Natives.cpp
@@ -90,7 +90,7 @@ SCRIPT_API(GetSVarsUpperIndex, int())
 	return component->size();
 }
 
-SCRIPT_API(GetSVarNameAtIndex, bool(int index, OutputOnlyString& output))
+SCRIPT_API(GetSVarNameAtIndex, int(int index, OutputOnlyString& output))
 {
 	GET_VAR_COMP(component, false);
 	StringView varname;
@@ -99,7 +99,7 @@ SCRIPT_API(GetSVarNameAtIndex, bool(int index, OutputOnlyString& output))
 	{
 		output = varname;
 	}
-	return res;
+	return std::get<StringView>(output).length();
 }
 
 SCRIPT_API(GetSVarType, int(const std::string& varname))

--- a/Server/Components/Pawn/Scripting/Variable/PlayerNatives.cpp
+++ b/Server/Components/Pawn/Scripting/Variable/PlayerNatives.cpp
@@ -76,7 +76,7 @@ SCRIPT_API(GetPVarsUpperIndex, int(IPlayer& player))
 	return component->size();
 }
 
-SCRIPT_API(GetPVarNameAtIndex, bool(IPlayer& player, int index, OutputOnlyString& output))
+SCRIPT_API(GetPVarNameAtIndex, int(IPlayer& player, int index, OutputOnlyString& output))
 {
 	GET_PLAYER_VAR_COMP(component, false);
 	StringView varname;
@@ -85,7 +85,7 @@ SCRIPT_API(GetPVarNameAtIndex, bool(IPlayer& player, int index, OutputOnlyString
 	{
 		output = varname;
 	}
-	return res;
+	return std::get<StringView>(output).length();
 }
 
 SCRIPT_API(GetPVarType, int(IPlayer& player, const std::string& varname))


### PR DESCRIPTION
This fixes an issue #1079 by adding string length as return value instead of true/false for the following natives:
* GetWeaponName
* NetStats_GetIpPort
* GetPVarNameAtIndex
* GetSVarNameAtIndex

Also related to [omp-stdlib #54](https://github.com/openmultiplayer/omp-stdlib/pull/54)