### PR TITLE
Fixed: train passenger sync

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ on:
 jobs:
   build-windows:
     name: Windows build
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     strategy:
       matrix:

--- a/Server/Components/Vehicles/vehicle.cpp
+++ b/Server/Components/Vehicles/vehicle.cpp
@@ -685,7 +685,11 @@ bool Vehicle::isDead()
 
 void Vehicle::_respawn()
 {
-	respawning = true;
+	if (!isTrainCarriage())
+	{
+		respawning = true;
+	}
+
 	const auto& entries = streamedFor_.entries();
 	for (IPlayer* player : entries)
 	{

--- a/Server/Components/Vehicles/vehicle.hpp
+++ b/Server/Components/Vehicles/vehicle.hpp
@@ -391,6 +391,19 @@ public:
 		return carriages;
 	}
 
+	bool isTrainCarriage()
+	{
+		const int model = getModel();
+		if (model == 569 || model == 570)
+		{
+			return true;
+		}
+		else
+		{
+			return false;
+		}
+	}
+
 	/// Sets the velocity of the vehicle.
 	void setVelocity(Vector3 velocity) override;
 

--- a/Server/Components/Vehicles/vehicle.hpp
+++ b/Server/Components/Vehicles/vehicle.hpp
@@ -394,14 +394,7 @@ public:
 	bool isTrainCarriage()
 	{
 		const int model = getModel();
-		if (model == 569 || model == 570)
-		{
-			return true;
-		}
-		else
-		{
-			return false;
-		}
+		return (model == 569 || model == 570);
 	}
 
 	/// Sets the velocity of the vehicle.

--- a/Server/Components/Vehicles/vehicles_impl.hpp
+++ b/Server/Components/Vehicles/vehicles_impl.hpp
@@ -48,7 +48,7 @@ private:
 				return false;
 			}
 
-			if (!lock.entry->isStreamedInForPlayer(peer) || peer.getState() != PlayerState_OnFoot)
+			if ((!lock.entry->isStreamedInForPlayer(peer) && !lock.entry->isTrainCarriage()) || peer.getState() != PlayerState_OnFoot)
 			{
 				return false;
 			}
@@ -91,7 +91,7 @@ private:
 			}
 
 			IPlayerVehicleData* vehData = queryExtension<IPlayerVehicleData>(peer);
-			if (vehData == nullptr || !lock.entry->isStreamedInForPlayer(peer) || !(peer.getState() == PlayerState_Driver || peer.getState() == PlayerState_Passenger) || vehData->getVehicle() != lock.entry)
+			if (vehData == nullptr || (!lock.entry->isStreamedInForPlayer(peer) && !lock.entry->isTrainCarriage()) || !(peer.getState() == PlayerState_Driver || peer.getState() == PlayerState_Passenger) || vehData->getVehicle() != lock.entry)
 			{
 				return false;
 			}

--- a/Server/Components/Vehicles/vehicles_impl.hpp
+++ b/Server/Components/Vehicles/vehicles_impl.hpp
@@ -48,7 +48,8 @@ private:
 				return false;
 			}
 
-			if ((!lock.entry->isStreamedInForPlayer(peer) && !lock.entry->isTrainCarriage()) || peer.getState() != PlayerState_OnFoot)
+			Vehicle* lockedVehicle = static_cast<Vehicle*>(lock.entry);
+			if ((!lockedVehicle->isStreamedInForPlayer(peer) && !lockedVehicle->isTrainCarriage()) || peer.getState() != PlayerState_OnFoot)
 			{
 				return false;
 			}
@@ -90,8 +91,9 @@ private:
 				return false;
 			}
 
+			Vehicle* lockedVehicle = static_cast<Vehicle*>(lock.entry);
 			IPlayerVehicleData* vehData = queryExtension<IPlayerVehicleData>(peer);
-			if (vehData == nullptr || (!lock.entry->isStreamedInForPlayer(peer) && !lock.entry->isTrainCarriage()) || !(peer.getState() == PlayerState_Driver || peer.getState() == PlayerState_Passenger) || vehData->getVehicle() != lock.entry)
+			if (vehData == nullptr || (!lockedVehicle->isStreamedInForPlayer(peer) && !lockedVehicle->isTrainCarriage()) || !(peer.getState() == PlayerState_Driver || peer.getState() == PlayerState_Passenger) || vehData->getVehicle() != lock.entry)
 			{
 				return false;
 			}

--- a/Server/Source/player_pool.hpp
+++ b/Server/Source/player_pool.hpp
@@ -1389,9 +1389,6 @@ struct PlayerPool final : public IPlayerPool, public NetworkEventHandler, public
 			IVehicle& vehicle = *lock.entry;
 			Player& player = static_cast<Player&>(peer);
 
-			if (vehicle.isRespawning())
-				return false;
-
 			const bool vehicleOk = vehicle.updateFromPassengerSync(passengerSync, peer);
 
 			if (!vehicleOk)

--- a/Server/Source/player_pool.hpp
+++ b/Server/Source/player_pool.hpp
@@ -1389,6 +1389,11 @@ struct PlayerPool final : public IPlayerPool, public NetworkEventHandler, public
 			IVehicle& vehicle = *lock.entry;
 			Player& player = static_cast<Player&>(peer);
 
+			if (vehicle.isRespawning())
+			{
+				return false;
+			}
+
 			const bool vehicleOk = vehicle.updateFromPassengerSync(passengerSync, peer);
 
 			if (!vehicleOk)


### PR DESCRIPTION
This PR fixes the following issues related to train passenger sync:
- Players inside a train carriage appear paused; OnPlayerUpdate is not triggered and GetPlayerVehicleID returns 0.
- Entering/exiting a train carriage does not trigger OnPlayerEnter/OnPlayerExitVehicle.