### PR TITLE
Implement KashCheery's timerfix's features

### DIFF
--- a/Server/Components/Pawn/Manager/Manager.cpp
+++ b/Server/Components/Pawn/Manager/Manager.cpp
@@ -460,6 +460,13 @@ void PawnManager::openAMX(PawnScript& script, bool isEntryScript, bool restartin
 	script.Register("IsRepeatingTimer", &utils::pawn_IsRepeatingTimer);
 	script.Register("GetTimerRemaining", &utils::pawn_GetTimerRemaining);
 	script.Register("GetTimerInterval", &utils::pawn_GetTimerInterval);
+	script.Register("SetTimerInterval", &utils::pawn_SetTimerInterval);
+	script.Register("PauseTimer", &utils::pawn_PauseTimer);
+	script.Register("ContinueTimer", &utils::pawn_ContinueTimer);
+	script.Register("IsTimerPaused", &utils::pawn_IsTimerPaused);
+	script.Register("KillAllTimers", &utils::pawn_KillAllTimers);
+	script.Register("IsTimerRunning", &utils::pawn_IsTimerRunning);
+	script.Register("GetRunningTimersCount", &utils::pawn_GetRunningTimersCount);
 	script.Register("SetModeRestartTime", &utils::pawn_SetModeRestartTime);
 	script.Register("GetModeRestartTime", &utils::pawn_GetModeRestartTime);
 

--- a/Server/Components/Pawn/utils.hpp
+++ b/Server/Components/Pawn/utils.hpp
@@ -15,6 +15,7 @@
 
 #include "format.hpp"
 #include "timers.hpp"
+#include "../Timers/timer.hpp"
 
 extern "C"
 {
@@ -235,10 +236,101 @@ inline cell AMX_NATIVE_CALL pawn_GetTimerInterval(AMX* amx, cell const* params)
 	return timer->interval().count();
 }
 
+inline cell AMX_NATIVE_CALL pawn_SetTimerInterval(AMX* amx, cell const* params)
+{
+	AMX_MIN_PARAMETERS("SetTimerInterval", params, 2);
+	ITimer* timer = PawnTimerImpl::Get()->getTimer(params[1]);
+	if (timer == nullptr || !timer->running())
+	{
+		return false;
+	}
+
+	int interval = static_cast<int>(params[2]);
+
+	if(interval < 1)
+	{
+		return false;
+	}
+
+	timer->setInterval(static_cast<Milliseconds>(interval));
+	return true;
+}
+
+inline cell AMX_NATIVE_CALL pawn_KillAllTimers(AMX* amx, cell const* params)
+{
+	AMX_MIN_PARAMETERS("KillAllTimers", params, 0);
+	ITimersComponent* timers = PawnManager::Get()->timers;
+	for (int timerid = 0; timerid < timers->count(); timerid++)
+    {
+	    ITimer* timer = PawnTimerImpl::Get()->getTimer(timerid);
+		if (timer == nullptr || !timer->running())
+	    {
+		    return false;
+	    }
+	    timer->kill();
+    }
+	return true;
+}
+
+inline cell AMX_NATIVE_CALL pawn_IsTimerRunning(AMX* amx, cell const* params)
+{
+	GET_TIMER(timer, "IsTimerRunning", false)
+	return timer->running();
+}
+
 inline cell AMX_NATIVE_CALL pawn_IsRepeatingTimer(AMX* amx, cell const* params)
 {
 	GET_TIMER(timer, "IsRepeatingTimer", false)
 	return timer->calls() == 0;
+}
+
+inline cell AMX_NATIVE_CALL pawn_GetRunningTimersCount(AMX* amx, cell const* params)
+{
+	AMX_MIN_PARAMETERS("GetRunningTimersCount", params, 0);
+	return PawnManager::Get()->timers->count();
+}
+
+inline cell AMX_NATIVE_CALL pawn_IsTimerPaused(AMX* amx, cell const* params)
+{
+	AMX_MIN_PARAMETERS("IsTimerPaused", params, 1);
+	ITimer* timer = PawnTimerImpl::Get()->getTimer(params[1]);
+	if (timer == nullptr || !timer->running())
+	{
+		return false;
+	}
+
+	if (!timer->paused())
+	{
+		return false;
+	}
+
+	return true;
+}
+
+inline cell AMX_NATIVE_CALL pawn_PauseTimer(AMX* amx, cell const* params)
+{
+	AMX_MIN_PARAMETERS("PauseTimer", params, 1);
+	ITimer* timer = PawnTimerImpl::Get()->getTimer(params[1]);
+	if (timer == nullptr || !timer->running())
+	{
+		return false;
+	}
+
+	timer->togglePause(true);
+	return true;
+}
+
+inline cell AMX_NATIVE_CALL pawn_ContinueTimer(AMX* amx, cell const* params)
+{
+	AMX_MIN_PARAMETERS("ContinueTimer", params, 1);
+	ITimer* timer = PawnTimerImpl::Get()->getTimer(params[1]);
+	if (timer == nullptr || !timer->running())
+	{
+		return false;
+	}
+
+	timer->togglePause(false);
+	return true;
 }
 
 inline cell AMX_NATIVE_CALL pawn_SetModeRestartTime(AMX* amx, cell const* params)

--- a/Server/Components/Timers/timers_main.cpp
+++ b/Server/Components/Timers/timers_main.cpp
@@ -73,6 +73,12 @@ public:
 			}
 			else
 			{
+				if (timer->paused())
+				{
+					++it;
+					continue;
+				}
+
 				const TimePoint now = Time::now();
 				const Milliseconds diff = duration_cast<Milliseconds>(now - timer->getTimeout());
 				if (diff.count() >= 0)


### PR DESCRIPTION
```pawn
#define GetTimerRemainingTime GetTimerRemaining
native KillAllTimers();
native IsTimerRunning(Timer:timerid);
native IsTimerPaused(Timer:timerid);
native PauseTimer(Timer:timerid);
native ContinueTimer(Timer:timerid);
native GetTimerInterval(Timer:timerid);
native SetTimerInterval(Timer:timerid, interval);
native GetTimerRemaining(Timer:timerid);
native GetRunningTimersCount();

stock bool:ToggleTimerPause(Timer:timerid)
{
    if(!IsValidTimer(timmerid))
        return false;
        
    if(IsTimerPaused(timerid))
        ContinueTimer(timerid);
    else
        PauseTimer(timerid);
    
    return true;
}
```

this is a fork of @NoPressF 's https://github.com/openmultiplayer/open.mp/pull/1087

TODO:
```pawn
native AddTimerHandler(Timer:timerid, handler[]);
native RemoveTimerHandler(Timer:timerid, handler[]);
native SetTimerDelay(Timer:timerid, delay);
```