### PR TITLE
Check provided mtu value against max allowed per client version

### DIFF
--- a/Server/Components/LegacyNetwork/legacy_network_impl.cpp
+++ b/Server/Components/LegacyNetwork/legacy_network_impl.cpp
@@ -793,6 +793,18 @@ void RakNetLegacyNetwork::update()
 	query.buildConfigDependentBuffers();
 
 	int mtu = *config.getInt("network.mtu");
+
+	static const auto maxMTU = *core->getConfig().getBool("network.allow_037_clients") ? MAX_MTU_037 : MAX_MTU_DL;
+
+	// Check if provided MTU is larger than the maximum allowed size for current targeted client(s).
+	// Example: 0.3.7 clients have a maximum MTU of 576 bytes, while 0.3DL clients have a maximum MTU of 1500 bytes.
+	// If that is the case, we will log a warning and set the MTU to the maximum allowed size so client won't experience packet loss/disconnects.
+	if (mtu > maxMTU)
+	{
+		core->logLn(LogLevel::Warning, "MTU %d is larger than the maximum allowed size %d for current targeted client(s).", mtu, maxMTU);
+		mtu = maxMTU;
+	}
+
 	rakNetServer.SetMTUSize(mtu);
 }
 

--- a/Server/Components/LegacyNetwork/legacy_network_impl.hpp
+++ b/Server/Components/LegacyNetwork/legacy_network_impl.hpp
@@ -25,6 +25,9 @@ using namespace Impl;
 
 #define MAGNITUDE_EPSILON 0.00001f
 
+#define MAX_MTU_037 576
+#define MAX_MTU_DL MAXIMUM_MTU_SIZE
+
 static const StaticArray<StringView, 2> ProtectedRules = {
 	"version", "allowed_clients"
 };


### PR DESCRIPTION
Fixes a bug for 0.3.7 clients which experience disconnects/packet loss if server mtu is higher than 576.