### PR TITLE
One big beautiful pull request

### DIFF
--- a/Server/Source/player_pool.hpp
+++ b/Server/Source/player_pool.hpp
@@ -1392,7 +1392,7 @@ struct PlayerPool final : public IPlayerPool, public NetworkEventHandler, public
 			IVehicle& vehicle = *lock.entry;
 			Player& player = static_cast<Player&>(peer);
 
-			if (vehicle.isRespawning())
+			if (vehicle.isRespawning() || (!vehicle.isStreamedInForPlayer(player) && !vehicle.isTrainCarriage()))
 			{
 				return false;
 			}

--- a/Server/Source/player_pool.hpp
+++ b/Server/Source/player_pool.hpp
@@ -1563,19 +1563,6 @@ struct PlayerPool final : public IPlayerPool, public NetworkEventHandler, public
 				return false;
 			}
 
-			float magnitude = glm::length(trailerSync.Quat);
-			if (std::abs(1.0f - magnitude) >= 0.000001f)
-			{
-				if (magnitude < 0.1f)
-				{
-					trailerSync.Quat = glm::vec4(0.5f);
-				}
-				else
-				{
-					trailerSync.Quat /= magnitude;
-				}
-			}
-
 			IVehicle* vehiclePtr = self.vehiclesComponent->get(trailerSync.VehicleID);
 			if (!vehiclePtr)
 			{
@@ -1596,6 +1583,20 @@ struct PlayerPool final : public IPlayerPool, public NetworkEventHandler, public
 			if (player.vehicleSync_.TrailerID != trailerSync.VehicleID)
 			{
 				return false;
+			}
+
+			// Normalise quaternions
+			float magnitude = glm::length(trailerSync.Quat);
+			if (std::abs(1.0f - magnitude) >= 0.000001f)
+			{
+				if (magnitude < 0.1f)
+				{
+					trailerSync.Quat = glm::vec4(0.5f);
+				}
+				else
+				{
+					trailerSync.Quat /= magnitude;
+				}
 			}
 
 			if (vehicle.updateFromTrailerSync(trailerSync, peer))

--- a/Server/Source/player_pool.hpp
+++ b/Server/Source/player_pool.hpp
@@ -1506,6 +1506,10 @@ struct PlayerPool final : public IPlayerPool, public NetworkEventHandler, public
 			{
 				return false;
 			}
+			else if (!unoccupiedSync.SeatID && player.state_ == PlayerState_Passenger)
+			{
+				return false;
+			}
 			else if (unoccupiedSync.SeatID && (player.state_ != PlayerState_Passenger || (playerVehicleData && playerVehicleData->getVehicle() != &vehicle) || (playerVehicleData && unoccupiedSync.SeatID != playerVehicleData->getSeat())))
 			{
 				return false;

--- a/Server/Source/player_pool.hpp
+++ b/Server/Source/player_pool.hpp
@@ -1404,10 +1404,10 @@ struct PlayerPool final : public IPlayerPool, public NetworkEventHandler, public
 				return false;
 			}
 
+			player.pos_ = vehicle.getPosition();
 			player.health_ = passengerSync.HealthArmour.x;
 			player.armour_ = passengerSync.HealthArmour.y;
 			player.armedWeapon_ = player.areWeaponsAllowed() ? passengerSync.WeaponID : 0;
-			player.pos_ = passengerSync.Position;
 
 			uint32_t newKeys = passengerSync.Keys;
 			switch (passengerSync.AdditionalKey)

--- a/Server/Source/player_pool.hpp
+++ b/Server/Source/player_pool.hpp
@@ -1392,7 +1392,8 @@ struct PlayerPool final : public IPlayerPool, public NetworkEventHandler, public
 			IVehicle& vehicle = *lock.entry;
 			Player& player = static_cast<Player&>(peer);
 
-			if (vehicle.isRespawning() || (!vehicle.isStreamedInForPlayer(player) && !vehicle.isTrainCarriage()))
+			int vehicleModel = vehicle.getModel();
+			if (vehicle.isRespawning() || (!vehicle.isStreamedInForPlayer(player) && !(vehicleModel == 569 || vehicleModel == 570))) // Check if vehicle is a train carriage (TODO: Move Vehicle::isTrainCarriage to SDK/Components/Vehicles/Impl/vehicle_models.hpp)
 			{
 				return false;
 			}


### PR DESCRIPTION
1. Fixes two critical issues in vehicle (driver) sync processing: they're both caused by wrong code order when pure validation checks which drops the packet executed *after* some side effects are applied, but those checks must be *before* them. This way it prevents partial updates from invalid driver sync. The first place was inside PlayerVehicleSyncHandler and the second in updateFromDriverSync.
2. Fixes critical behavior difference when passenger sync could be passed with any passenger position a cheater want to spoof. SA-MP server ignores what was received by the sender and rewrites the new passenger position with the one his vehicle has now. This change prevents areas for abuse in the existing SA-MP scripts: for example, many anticheats don't check passengers for teleport hack because according to original SA-MP behavior the passenger can update his position in vehicle only if it has no driver, via unoccupied sync.
3. Fixes passenger sync spoofing for non-streamed vehicles, considering train carriages ([#1053](https://github.com/openmultiplayer/open.mp/pull/1053)).
4. Drops unoccupied sync if the cheater send vehicle update from 0 seat being actually a passenger (the check for not being a passenger and updating unoccupied vehicle from passenger seats already was presented, though).
5. Normalizes trailer quaternion from the server side since samp clients don't do it specifically for trailer sync for some reason, so it can be abused by cheaters like they do with unoccupied sync roll/direction matrix.