### PR TITLE
Store natives globally & ability to call them from using SDK

### DIFF
--- a/Server/Components/Pawn/Script/Script.cpp
+++ b/Server/Components/Pawn/Script/Script.cpp
@@ -381,6 +381,15 @@ __attribute__((noinline)) int amx_FindPublic_impl(AMX* amx, const char* name, in
 
 __attribute__((noinline)) int AMXAPI amx_Register_impl(AMX* amx, const AMX_NATIVE_INFO* list, int number)
 {
+	// Register all natives in the global registry
+	if (list != NULL)
+	{
+		for (int j = 0; (j < number || number == -1) && list[j].name != NULL; j++)
+		{
+			GlobalNativeRegistry::RegisterNative(list[j].name, list[j].func);
+		}
+	}
+
 	AMX_FUNCPART* func;
 	AMX_HEADER* hdr;
 	int i, numnatives, err;

--- a/Server/Components/Pawn/Script/Script.hpp
+++ b/Server/Components/Pawn/Script/Script.hpp
@@ -301,12 +301,10 @@ private:
 				auto readback = [ref, bufferSize](cell* data)
 				{
 					auto& vec = ref->ref();
-					vec.clear();
-					vec.reserve(bufferSize);
 					vec.resize(bufferSize, 0);
 					for (size_t j = 0; j < bufferSize; ++j)
 					{
-						vec.push_back(static_cast<int>(data[j]));
+						vec[j] = static_cast<int>(data[j]);
 					}
 				};
 
@@ -331,12 +329,10 @@ private:
 				auto readback = [ref, bufferSize](cell* data)
 				{
 					auto& vec = ref->ref();
-					vec.clear();
-					vec.reserve(bufferSize);
-					vec.resize(bufferSize, 0);
+					vec.resize(bufferSize, 0.0f);
 					for (size_t j = 0; j < bufferSize; ++j)
 					{
-						vec.push_back(amx_ctof(data[j]));
+						vec[j] = amx_ctof(data[j]);
 					}
 				};
 


### PR DESCRIPTION
### Info
The natives that were not used in a script were not able to be called (because they weren't actually registered, when `amx_Register` was called) so now we're keeping a container of all natives. Also introducing a new function to `IPawnScript`, named `IPawnScript::CallNative` so SDK users are able to call those globally stored natives using this function which handles argument types (both values and refs)

### Examples:
#### Normal arguments:
```cpp
auto result = script.CallNative("SetPlayerPos", playerid, 1352.0f, 363.0f, 200.0f);

// float return value
float result = script.CallNative<float>("GetPlayerGravity", playerid);
```

#### Reference arguments:
```cpp
PawnRef<float> x, y, z;
script.CallNative("GetPlayerPos", 0, x, y, z);
printf("Pos: x = %f, y = %f, z = %f\n", x.get(), y.get(), z.get());

// String ref
PawnRef<String> playerName(24);
script.CallNative("GetPlayerName", playerid, playerName, playerName.size());
printf("Player %d name is %s\n", playerid, playerName.c_str());

// Array ref
PawnRef<DynamicArray<int>> players(100);
script.CallNative("GetPlayers", players, players.size());
for (int playerid : players.get())
{
    printf("Player %d is in server\n", playerid);
}
```

The `PawnRef` wrapper:
1. Allocates a cell in AMX heap memory
2. Writes the initial value to that cell
3. Passes the AMX address to the native
4. Reads back the modified value after the native returns
5. Automatically cleans up allocated memory
