### PR TITLE
Add onTick callback for PawnEventHandler

### DIFF
--- a/Server/Components/Pawn/main.cpp
+++ b/Server/Components/Pawn/main.cpp
@@ -256,6 +256,13 @@ public:
 	{
 		PawnManager::Get()->pluginManager.ProcessTick();
 		PawnManager::Get()->ProcessTick(elapsed, now);
+		
+		// Notify registered event handlers (helps us do work and allows async plugins to process callbacks)
+		PawnManager::Get()->eventDispatcher.dispatch(
+			[elapsed, now](PawnEventHandler* handler) {
+				handler->onTick(elapsed, now);
+			}
+		);
 	}
 
 	void onFree(IComponent* component) override


### PR DESCRIPTION
Right now async plugins need users to setup timers manually? didnt found other sulution.This adds an optional onTick callback so plugins can handle callbacks automatically without requiring script timers.

Depends on SDK PR: openmultiplayer/open.mp-sdk#57.

Changes:
SDK: Added onTick() to PawnEventHandler (default does nothing)
 Component: Call eventDispatcher in main.cpp onTick