### PR TITLE
Fix for random occurrence of player state none

### DIFF
--- a/Server/Source/player_impl.hpp
+++ b/Server/Source/player_impl.hpp
@@ -631,12 +631,6 @@ struct Player final : public IPlayer, public PoolIDProvider, public NoCopy
 			toSpawn_ = true;
 			spectateData_.type = PlayerSpectateData::ESpectateType::None;
 			spectateData_.spectateID = INVALID_PLAYER_ID;
-
-			// When client exits spectate mode it will attempt to request a class or to spawn
-			// but the server still thinks the it is in it's previous state.
-			// This can lead to those requests being rejected.
-			// This state update will fix that.
-			setState(PlayerState_None, false);
 		}
 		else
 		{


### PR DESCRIPTION
This should finally fix #1008 with pretty critical behavior difference, when omp server as a workaround sets the player state to `PLAYER_STATE_NONE` when player leaves spectating. As the comment says the reasons:
https://github.com/openmultiplayer/open.mp/blob/59fd6e558732ea8f577d63e988c7372b0dc44424/Server/Source/player_impl.hpp#L635-L638
it is supposed to update the player state to pass further checks inside RequestClass or RequestSpawn events, one of which will be called by player when he exits spectating.

But what we see in those places are only such checks:
https://github.com/openmultiplayer/open.mp/blob/59fd6e558732ea8f577d63e988c7372b0dc44424/Server/Components/Classes/classes_main.cpp#L156-L160
^ in PlayerRequestClassHandler, and:
https://github.com/openmultiplayer/open.mp/blob/59fd6e558732ea8f577d63e988c7372b0dc44424/Server/Source/player_pool.hpp#L64-L68
^ in PlayerRequestSpawnRPCHandler

So, if player still has [PLAYER_STATE_SPECTATING](https://open.mp/ru/docs/scripting/resources/playerstates), it **will** pass both of those checks, since spectating state is not in the range of forbidden states which are blocked to call all the mentioned events.

Meanwhile having manually update player states to random ones leads to behavior differences, and in this case it's pretty critical one since it break many protections against state change spoofing and thus falsely triggers on fair players ([#325](https://github.com/NexiusTailer/Nex-AC/issues/325) as example). Not to say that such actions are also undocumented and doesn't match SA-MP behavior for any other scripts which aren't designed to consider similar server behavior surprises.