### PR TITLE
fix: clear checkingList when component is reseted

### DIFF
--- a/Server/Components/GangZones/gangzone.cpp
+++ b/Server/Components/GangZones/gangzone.cpp
@@ -136,6 +136,7 @@ public:
 
 	void reset() override
 	{
+		checkingList.clear();
 		storage.clear();
 		// Clear all the IDs.
 		for (int i = 0; i != GANG_ZONE_POOL_SIZE; ++i)
@@ -161,7 +162,6 @@ public:
 
 			for (auto gangzone : checkingList.entries())
 			{
-
 				// Only check visible gangzones
 				if (!gangzone->isShownForPlayer(player))
 				{


### PR DESCRIPTION
if the server is restarted using gmx, the checkingList will remain intact and won't be cleared. this results in the entries becoming invalid after the restart, causing the server to crash but only when the size of checkingList is greater than 1.

cc: @zookyy for discovering the bug

```pawn
#define MIXED_SPELLINGS

#include <open.mp>

main() {}

#define XYZ(%0) %0[0], %0[1], %0[2]


new Float: g_HunterFields[][4] = {
    { -1915.0, -2458.0, -1371.0, -1802.0 },
    { -697.0, -2133.0, -398.0, -1912.0 },
    { -1098.0, -2485.0, -834.0, -2170.0 }
};

new g_HunterZones[sizeof(g_HunterFields)];

public OnGameModeInit()
{

    for(new i = 0; i < sizeof(g_HunterFields); i++) {

        g_HunterZones[i] = GangZoneCreate(XYZ(g_HunterFields[i]), g_HunterFields[i][3]);

        UseGangZoneCheck(g_HunterZones[i], true);
    }

    return 1;
}

public OnPlayerConnect(playerid)
{
    
    TogglePlayerSpectating(playerid, true);    

    return 1;
}
```
