### PR TITLE
Ignore networked ID_CONNECTION_LOST packet.

### DIFF
--- a/Server/Components/LegacyNetwork/legacy_network_impl.cpp
+++ b/Server/Components/LegacyNetwork/legacy_network_impl.cpp
@@ -429,6 +429,7 @@ void RakNetLegacyNetwork::OnPlayerConnect(RakNet::RPCParameters* rpcParams, void
 
 		network->core->logLn(LogLevel::Warning, "Invalid client connecting from %.*s", int(addressString.length()), addressString.data());
 		network->rakNetServer.Kick(rpcParams->sender);
+		network->rakNetServer.AddToBanList(addressString.data(), 15'000u);
 		return;
 	}
 

--- a/Server/Components/NPCs/npcs_impl.cpp
+++ b/Server/Components/NPCs/npcs_impl.cpp
@@ -27,8 +27,11 @@ void NPCComponent::onInit(IComponentList* components)
 		objects = components->queryComponent<IObjectsComponent>();
 		actors = components->queryComponent<IActorsComponent>();
 
-		vehicles->getPoolEventDispatcher().addEventHandler(this);
-		vehicles->getEventDispatcher().addEventHandler(this);
+		if (vehicles != nullptr)
+		{
+			vehicles->getPoolEventDispatcher().addEventHandler(this);
+			vehicles->getEventDispatcher().addEventHandler(this);
+		}
 	}
 }
 


### PR DESCRIPTION
Ignore networked `ID_CONNECTION_LOST` packets as they are internal. This prevents 'Server Full' exploits. 
Invalid clients are now temporarily banned for 15s to prevent console and log spam.