### PR TITLE
Fix NPC component cleanup

### DIFF
--- a/Server/Components/NPCs/npcs_impl.cpp
+++ b/Server/Components/NPCs/npcs_impl.cpp
@@ -37,6 +37,12 @@ void NPCComponent::onInit(IComponentList* components)
 
 void NPCComponent::free()
 {
+	auto shallowCopy = storage._entries();
+	for (auto npc : shallowCopy)
+	{
+		release(npc->getID());
+	}
+
 	core->getEventDispatcher().removeEventHandler(this);
 	core->getPlayers().getPlayerDamageDispatcher().removeEventHandler(this);
 	core->getPlayers().getPoolEventDispatcher().removeEventHandler(this);


### PR DESCRIPTION
This PR solves #1160.

### Problem

NPCs were not removed from the player pool during `NPCComponent::free`, causing a crash.

During shutdown, the NPC network is destroyed while NPCs remain in the player pool. Later, when textdraws are destroyed in `OnGameModeExit`, a "hide textdraw" packet is sent to each player—including NPCs. This causes a crash when the packet is tried to be sent through the already-destroyed NPC network.

### Solution

Release all NPCs before destroying the component, ensuring they're removed from the player pool