### PR TITLE
Tweaks for pawn component and more

### DIFF
--- a/Server/Components/Fixes/fixes.cpp
+++ b/Server/Components/Fixes/fixes.cpp
@@ -496,7 +496,7 @@ public:
 			// Gametext style 13 (stunt).
 			td->setLetterSize({ 0.58, 2.42 });
 			td->setAlignment(TextDrawAlignment_Center);
-			td->setColour(Colour(0xDD, 0xDD, 0xDB, 0xFF));
+			td->setColour(Colour(0xE1, 0xE1, 0xE1, 0xFF));
 			td->setShadow(2);
 			td->setOutline(0);
 			td->setBackgroundColour(Colour(0x00, 0x00, 0x00, 0xFF));
@@ -510,15 +510,13 @@ public:
 			// Gametext style 14 (clock).
 			td->setLetterSize({ 0.55, 2.2 });
 			td->setAlignment(TextDrawAlignment_Right);
-			// There's some debate over this colour.  It seems some versions
-			// somehow end up with `0xE1E1E1FF` instead.
 			td->setColour(Colour(0xE1, 0xE1, 0xE1, 0xFF));
 			td->setShadow(0);
 			td->setOutline(2);
 			td->setBackgroundColour(Colour(0x00, 0x00, 0x00, 0xFF));
 			td->setStyle(TextDrawStyle_3);
 			td->setProportional(false);
-			td->useBox(false);
+			td->useBox(true);
 			td->setBoxColour(Colour(0x00, 0x00, 0x00, 0x00));
 			td->setTextSize({ 400.0, 20.0 });
 			break;
@@ -529,11 +527,11 @@ public:
 			td->setColour(Colour(0xFF, 0xFF, 0xFF, 0x96));
 			td->setShadow(0);
 			td->setOutline(0);
-			td->setBackgroundColour(Colour(0x00, 0x00, 0x00, 0xFF));
+			td->setBackgroundColour(Colour(0x00, 0x00, 0x00, 0x00));
 			td->setStyle(TextDrawStyle_1);
 			td->setProportional(true);
 			td->useBox(true);
-			td->setBoxColour(Colour(0x00, 0x00, 0x00, 0x80));
+			td->setBoxColour(Colour(0x00, 0x00, 0x00, 0xDD));
 			td->setTextSize({ 230.5, 200.0 });
 			break;
 		}

--- a/Server/Components/Pawn/PluginManager/PluginManager.cpp
+++ b/Server/Components/Pawn/PluginManager/PluginManager.cpp
@@ -16,12 +16,13 @@ struct BrokenPluginMessageData
 	StringView message;
 };
 
-static const StaticArray<BrokenPluginMessageData, 24> BrokenPlugins = {
+static const StaticArray<BrokenPluginMessageData, 25> BrokenPlugins = {
 	{
 		{ "YSF", "It requires memory hacking to run and is therefore broken on open.mp, we already added many built-in features from YSF to open.mp and the rest are coming" },
 		{ "YSF_DL", "It requires memory hacking to run and is therefore broken on open.mp, we already added many built-in features from YSF to open.mp and the rest are coming" },
 		{ "YSF_static", "It requires memory hacking to run and is therefore broken on open.mp, we already added many built-in features from YSF to open.mp and the rest are coming" },
 		{ "YSF_DL_static", "It requires memory hacking to run and is therefore broken on open.mp, we already added many built-in features from YSF to open.mp and the rest are coming" },
+		{ "fixes2", "It requires memory hacking to run and is therefore broken on open.mp. There should be a replacement component supported by open.mp" },
 		{ "FCNPC", "It requires memory hacking to run and is therefore broken on open.mp, we already have NPC component with many built-in features in open.mp" },
 		{ "FCNPC-DL", "It requires memory hacking to run and is therefore broken on open.mp, we already have NPC component with many built-in features in open.mp" },
 		{ "SKY", "It requires memory hacking to run and is therefore broken on open.mp. There should be a replacement component supported by open.mp" },

--- a/Server/Components/Pawn/Script/Script.cpp
+++ b/Server/Components/Pawn/Script/Script.cpp
@@ -475,7 +475,7 @@ __attribute__((noinline)) int AMXAPI amx_Allot_impl(AMX* amx, int cells, cell* a
 	{
 		PawnManager::Get()->core->logLn(LogLevel::Error, "Unable to find enough memory for your data.");
 		PawnManager::Get()->core->logLn(LogLevel::Error, "Size: %i bytes, Available space: %i bytes, Need extra size: %i bytes",
-			int(amx->hea + cells * sizeof(cell)), amx->stk, int(amx->hea + cells * sizeof(cell) - amx->stk));
+			int(amx->hea + cells * sizeof(cell)), int(amx->stk), int(amx->hea + cells * sizeof(cell) - amx->stk));
 		PawnManager::Get()->core->logLn(LogLevel::Error, "You can increase your available memory size by using `#pragma dynamic %i`.",
 			int(amx->hea / sizeof(cell) + cells));
 		return AMX_ERR_MEMORY;

--- a/Server/Components/Pawn/format.cpp
+++ b/Server/Components/Pawn/format.cpp
@@ -754,7 +754,7 @@ reswitch:
 			cell* ptr = reinterpret_cast<cell*>(*cptr);
 			if (!ptr)
 			{
-				PawnManager::Get()->core->logLn(LogLevel::Error, "Invalid vector string handle provided (%d)", *cptr);
+				PawnManager::Get()->core->logLn(LogLevel::Error, "Invalid vector string handle provided (%d)", int(*cptr));
 				return 0;
 			}
 

--- a/Server/Components/Pawn/utils.hpp
+++ b/Server/Components/Pawn/utils.hpp
@@ -34,24 +34,24 @@ extern "C"
 
 #include "Manager/Manager.hpp"
 
-#define AMX_CHECK_PARAMETERS(name, params, n)                                                                                                 \
-	do                                                                                                                                        \
-	{                                                                                                                                         \
-		if (amx_NumParams(params) != (n))                                                                                                     \
-		{                                                                                                                                     \
-			PawnManager::Get()->core->logLn(LogLevel::Error, "Incorrect parameters given to `%s`: %u != %u", name, amx_NumParams(params), n); \
-			return 0;                                                                                                                         \
-		}                                                                                                                                     \
+#define AMX_CHECK_PARAMETERS(name, params, n)                                                                                                           \
+	do                                                                                                                                                  \
+	{                                                                                                                                                   \
+		if (amx_NumParams(params) != (n))                                                                                                               \
+		{                                                                                                                                               \
+			PawnManager::Get()->core->logLn(LogLevel::Error, "Incorrect parameters given to `%s`: %u != %u", name, uint32_t(amx_NumParams(params)), n); \
+			return 0;                                                                                                                                   \
+		}                                                                                                                                               \
 	} while (0)
 
-#define AMX_MIN_PARAMETERS(name, params, n)                                                                                                     \
-	do                                                                                                                                          \
-	{                                                                                                                                           \
-		if (amx_NumParams(params) < (n))                                                                                                        \
-		{                                                                                                                                       \
-			PawnManager::Get()->core->logLn(LogLevel::Error, "Insufficient parameters given to `%s`: %u < %u", name, amx_NumParams(params), n); \
-			return 0;                                                                                                                           \
-		}                                                                                                                                       \
+#define AMX_MIN_PARAMETERS(name, params, n)                                                                                                               \
+	do                                                                                                                                                    \
+	{                                                                                                                                                     \
+		if (amx_NumParams(params) < (n))                                                                                                                  \
+		{                                                                                                                                                 \
+			PawnManager::Get()->core->logLn(LogLevel::Error, "Insufficient parameters given to `%s`: %u < %u", name, uint32_t(amx_NumParams(params)), n); \
+			return 0;                                                                                                                                     \
+		}                                                                                                                                                 \
 	} while (0)
 
 namespace utils
@@ -176,7 +176,7 @@ inline cell AMX_NATIVE_CALL pawn_settimer(AMX* amx, cell const* params)
 
 	if (params[2] < 0)
 	{
-		PawnManager::Get()->core->logLn(LogLevel::Error, "Invalid SetTimer interval (%i) when calling: %s", params[2], callback);
+		PawnManager::Get()->core->logLn(LogLevel::Error, "Invalid SetTimer interval (%i) when calling: %s", int(params[2]), callback);
 		return false;
 	}
 
@@ -192,7 +192,7 @@ inline cell AMX_NATIVE_CALL pawn_settimerex(AMX* amx, cell const* params)
 
 	if (params[2] < 0)
 	{
-		PawnManager::Get()->core->logLn(LogLevel::Error, "Invalid SetTimerEx interval (%i) when calling: %s", params[2], callback);
+		PawnManager::Get()->core->logLn(LogLevel::Error, "Invalid SetTimerEx interval (%i) when calling: %s", int(params[2]), callback);
 		return false;
 	}
 
@@ -413,7 +413,7 @@ inline cell AMX_NATIVE_CALL pawn_Script_CallOne(AMX* amx, cell const* params)
 	amx = PawnManager::Get()->AMXFromID(params[1]);
 	if (amx == nullptr)
 	{
-		PawnManager::Get()->core->logLn(LogLevel::Error, "Could not find target script (%u) in `Script_CallOne`", params[1]);
+		PawnManager::Get()->core->logLn(LogLevel::Error, "Could not find target script (%u) in `Script_CallOne`", uint32_t(params[1]));
 		return 0;
 	}
 	amx_StrParamChar(amx, params[2], name);
@@ -490,7 +490,7 @@ inline cell AMX_NATIVE_CALL pawn_Script_CallOneByIndex(AMX* amx, cell const* par
 	amx = PawnManager::Get()->AMXFromID(params[1]);
 	if (amx == nullptr)
 	{
-		PawnManager::Get()->core->logLn(LogLevel::Error, "Could not find target script (%u) in `Script_CallOneByIndex`", params[1]);
+		PawnManager::Get()->core->logLn(LogLevel::Error, "Could not find target script (%u) in `Script_CallOneByIndex`", uint32_t(params[1]));
 		return 0;
 	}
 	int


### PR DESCRIPTION
1. Apply the changes which was behind the repo when Amir send .diff patches to help me compile omp server with `PAWN_CELL_SIZE` changed to 64, so I just propose it now to be merged here for all who might wanna do the same
2. Sync pawn submodule to the latest commits, including these fixes:
  - fix offset in `memcpy` which was applied to `source` instead of `dest`
  - fix `fwrite` skipping last symbol if the passed string is packed
3. Backport some gametext tweaks from [gametext+ library](https://github.com/itsneufox/GameText-Plus) into the deprecated fixes component implementation. This is made purely for people who may find it global github search or in google, to provide more or less precise textdraw data for building server-side gametexts, as previous presets have a few mistakes for some gametext styles
4. Add very old [fixes2](https://github.com/CallistoGaming/Fixes2) memhack plugin into the broken plugins list