### PR TITLE
NPC_Respawn now resets death state to false

### DIFF
--- a/Server/Components/NPCs/NPC/npc.cpp
+++ b/Server/Components/NPCs/NPC/npc.cpp
@@ -329,6 +329,7 @@ void NPC::respawn()
 		resumePath();
 	}
 
+	dead_ = false;
 	lastDamager_ = nullptr;
 	lastDamagerWeapon_ = PlayerWeapon_End;
 


### PR DESCRIPTION
Single line that solves #1183, by now resetting the death state of such NPC to false, mimicing the actual implementation of NPC::spawn. Also fixes NPC_IsDead for NPCs that have been respawned using NPC_Respawn.