### PR TITLE
Fix player class validations for transitional state

### DIFF
--- a/Server/Components/Classes/classes_main.cpp
+++ b/Server/Components/Classes/classes_main.cpp
@@ -154,7 +154,8 @@ private:
 			}
 
 			PlayerState state = peer.getState();
-			if (state == PlayerState_Spawned || (state >= PlayerState_OnFoot && state < PlayerState_Wasted))
+			if (!static_cast<Player&>(peer).leftSpectating_
+				&& (state == PlayerState_Spawned || (state >= PlayerState_OnFoot && state < PlayerState_Wasted)))
 			{
 				return false;
 			}

--- a/Server/Source/player_impl.hpp
+++ b/Server/Source/player_impl.hpp
@@ -109,6 +109,7 @@ struct Player final : public IPlayer, public PoolIDProvider, public NoCopy
 	PlayerChatBubble chatBubble_;
 	const bool isBot_;
 	bool toSpawn_;
+	bool leftSpectating_;
 	TimePoint lastGameTimeUpdate_;
 	PlayerSpectateData spectateData_;
 	float gravity_;
@@ -195,6 +196,7 @@ struct Player final : public IPlayer, public PoolIDProvider, public NoCopy
 		targetActor_ = INVALID_ACTOR_ID;
 		chatBubbleExpiration_ = Time::now();
 		toSpawn_ = false;
+		leftSpectating_ = false;
 		lastGameTimeUpdate_ = TimePoint();
 		spectateData_ = { false, INVALID_PLAYER_ID, PlayerSpectateData::ESpectateType::None };
 		gravity_ = 0.0f;
@@ -252,6 +254,7 @@ struct Player final : public IPlayer, public PoolIDProvider, public NoCopy
 		, chatBubbleExpiration_(Time::now())
 		, isBot_(params.bot)
 		, toSpawn_(false)
+		, leftSpectating_(false)
 		, lastGameTimeUpdate_()
 		, spectateData_({ false, INVALID_PLAYER_ID, PlayerSpectateData::ESpectateType::None })
 		, gravity_(0.0f)
@@ -639,6 +642,8 @@ struct Player final : public IPlayer, public PoolIDProvider, public NoCopy
 			// This is due code conflicts and issues brough into samp script when state change event
 			// Is called in here, which it shouldn't according to samp structure.
 		}
+
+		leftSpectating_ = !spectating;
 
 		NetCode::RPC::TogglePlayerSpectating togglePlayerSpectatingRPC;
 		spectateData_.spectating = spectating;

--- a/Server/Source/player_pool.hpp
+++ b/Server/Source/player_pool.hpp
@@ -62,7 +62,8 @@ struct PlayerPool final : public IPlayerPool, public NetworkEventHandler, public
 		bool onReceive(IPlayer& peer, NetworkBitStream& bs) override
 		{
 			PlayerState state = peer.getState();
-			if (state == PlayerState_Spawned || (state >= PlayerState_OnFoot && state < PlayerState_Wasted))
+			if (!static_cast<Player&>(peer).leftSpectating_
+				&& (state == PlayerState_Spawned || (state >= PlayerState_OnFoot && state < PlayerState_Wasted)))
 			{
 				return false;
 			}
@@ -458,6 +459,7 @@ struct PlayerPool final : public IPlayerPool, public NetworkEventHandler, public
 			Player& player = static_cast<Player&>(peer);
 			if (player.toSpawn_ || player.isBot_)
 			{
+				player.leftSpectating_ = false;
 				player.setState(PlayerState_Spawned);
 				player.controllable_ = true;
 


### PR DESCRIPTION
### Problem

When we do such code on the current version of open.mp server:

```Pawn
ForceClassSelection(playerid);
SetPlayerHealth(playerid, 0.0);

// must be applied in a single tick, at once
TogglePlayerSpectating(playerid, true);
TogglePlayerSpectating(playerid, false);
```

Player who entered class selection most likely won't be able to select a class and spawn: all buttons won't be clickable like something blocks OnPlayerRequestClass and OnPlayerRequestSpawn callbacks on the server even before they reach your pawn script. This method is actually used to spawn player immediately [here](https://github.com/oscar-broman/samp-weapon-config/blob/master/weapon-config.inc#L6869-L6870), in weapon-config, so it's not something marginal.

***

The root cause is that `TogglePlayerSpectating` cannot manage to properly update the player's state when toggling on and off quickly, because the client doesn't have enough time to send at least one spectating sync packet back to the server (and thus the server won't update his state to spectating a bit further).

The validation checks inside class selection events fully rely on player state being always accurate, and thus reject any attempt to change classes or to spawn with selected class, if the player considered to be spawned (by being in one of such player states: onfoot, driver, passenger or spawned).

Finally, when our code above is executed, player who was in onfoot player state **will still be with onfoot state** for the server when he enters class selection, because toggling spectator mode was done too fast, without player state change to the spectating state which considered non-spawned one, and thus lets the validation checks inside class selection events to be passed.

***

### Solution

We might be forcefully set player state to some non-spawned when `TogglePlayerSpectating` is called with `toggle` parameter set to false, but messing with player states is hacky and it previously lead to even more problems.

Instead, this PR [implements transitional flag](https://github.com/openmultiplayer/open.mp/pull/1179#issuecomment-3709720075) when the player is being left from spectating (which is true until spawn). This period between leaving spectator and actual spawn is now considered a valid case to process class selection events, even if validations inside them see that this player has inappropriate player state.