### PR TITLE
Managing Model Downloading, implemented some YSF natives

### DIFF
--- a/Server/Components/CAPI/Impl/CustomModels/APIs.cpp
+++ b/Server/Components/CAPI/Impl/CustomModels/APIs.cpp
@@ -115,3 +115,26 @@ OMP_CAPI(CustomModel_GetPath, bool(int modelId, OutputStringViewPtr dffPath, Out
 
 	return status;
 }
+
+OMP_CAPI(SetModelDownloadAtConnect, bool(bool value))
+{
+	auto models = ComponentManager::Get()->models;
+	
+	if (!models)
+		return false;
+
+	return models->setModelDownloadAtConnect(value);
+}
+
+OMP_CAPI(StartDownloadForPlayer, bool(objectPtr player))
+{
+	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	auto models = ComponentManager::Get()->models;
+	
+	if (!models)
+	{
+		return false;
+	}
+		
+	return models->startDownloadForPlayer(*player_);
+}

--- a/Server/Components/CAPI/Impl/Players/APIs.cpp
+++ b/Server/Components/CAPI/Impl/Players/APIs.cpp
@@ -596,6 +596,12 @@ OMP_CAPI(Player_GetBuildingsRemoved, int(objectPtr player))
 	return count;
 }
 
+OMP_CAPI(Player_IsBuildingRemoved, bool(objectPtr player, int model, float x, float y, float z, float radius))
+{
+	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
+	return player_->isDefaultObjectRemoved(model, {x, y, z}, radius);
+}
+
 OMP_CAPI(Player_RemoveFromVehicle, bool(objectPtr player, bool force))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);

--- a/Server/Components/CAPI/Impl/Players/APIs.cpp
+++ b/Server/Components/CAPI/Impl/Players/APIs.cpp
@@ -592,7 +592,7 @@ OMP_CAPI(Player_RemoveBuilding, bool(objectPtr player, int model, float x, float
 OMP_CAPI(Player_GetBuildingsRemoved, int(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	int count = player_->getDefaultObjectsRemoved();
+	int count = player_->getDefaultObjectsRemovedCount();
 	return count;
 }
 

--- a/Server/Components/CAPI/Impl/Players/APIs.cpp
+++ b/Server/Components/CAPI/Impl/Players/APIs.cpp
@@ -599,7 +599,7 @@ OMP_CAPI(Player_GetBuildingsRemoved, int(objectPtr player))
 OMP_CAPI(Player_IsBuildingRemoved, bool(objectPtr player, int model, float x, float y, float z, float radius))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, false);
-	return player_->isDefaultObjectRemoved(model, {x, y, z}, radius);
+	return player_->isDefaultObjectRemoved(model, { x, y, z }, radius);
 }
 
 OMP_CAPI(Player_RemoveFromVehicle, bool(objectPtr player, bool force))

--- a/Server/Components/CAPI/Impl/Vehicles/APIs.cpp
+++ b/Server/Components/CAPI/Impl/Vehicles/APIs.cpp
@@ -780,3 +780,23 @@ OMP_CAPI(Vehicle_CountOccupants, int(objectPtr vehicle))
 
 	return occupants;
 }
+
+OMP_CAPI(ShowVehicle, bool(objectPtr vehicle))
+{
+	POOL_ENTITY_RET(vehicles, IVehicle, vehicle, vehicle_, 0);
+	vehicle_->toggleHide(false);
+	return true;
+}
+
+OMP_CAPI(HideVehicle, bool(objectPtr vehicle))
+{
+	POOL_ENTITY_RET(vehicles, IVehicle, vehicle, vehicle_, 0);
+	vehicle_->toggleHide(true);
+	return true;
+}
+
+OMP_CAPI(IsVehicleHidden, bool(objectPtr vehicle))
+{
+	POOL_ENTITY_RET(vehicles, IVehicle, vehicle, vehicle_, 0);
+	return vehicle_->isHidden();
+}

--- a/Server/Components/CustomModels/models.cpp
+++ b/Server/Components/CustomModels/models.cpp
@@ -718,7 +718,7 @@ public:
 		if (player.getClientVersion() != ClientVersion::ClientVersion_SAMP_03DL)
 			return;
 
-		if(DownloadAtConnect)
+		if (DownloadAtConnect)
 			promptModelsForPlayer(player);
 	}
 
@@ -735,7 +735,7 @@ public:
 		{
 			return;
 		}
-		if(DownloadAtConnect)
+		if (DownloadAtConnect)
 		{
 			webServer->allowIPAddress(player.getNetworkData().networkID.address.v4);
 		}
@@ -780,7 +780,7 @@ public:
 
 	bool startDownloadForPlayer(IPlayer& player) override
 	{
-		if(DownloadAtConnect)
+		if (DownloadAtConnect)
 			return false;
 
 		webServer->allowIPAddress(player.getNetworkData().networkID.address.v4);

--- a/Server/Components/CustomModels/models.cpp
+++ b/Server/Components/CustomModels/models.cpp
@@ -303,6 +303,7 @@ private:
 	bool usingCdn = false;
 	uint16_t httpThreads = 50; // default max_players is 50
 	bool showCRCLogs = false;
+	bool DownloadAtConnect = true;
 
 	DefaultEventDispatcher<PlayerModelsEventHandler> eventDispatcher;
 
@@ -695,11 +696,8 @@ public:
 		return file.name;
 	}
 
-	void onPlayerClientInit(IPlayer& player) override
+	void promptModelsForPlayer(IPlayer& player)
 	{
-		if (player.getClientVersion() != ClientVersion::ClientVersion_SAMP_03DL)
-			return;
-
 		const auto modelsCount = storage.size();
 		for (auto i = 0; i != modelsCount; ++i)
 		{
@@ -707,13 +705,21 @@ public:
 			storage[i]->write(modelInfo);
 			PacketHelper::send(modelInfo, player);
 		}
-
 		// If client reconnected (lost connection to the server) let's force it to download files if there are any.
 		NetCode::RPC::SetPlayerVirtualWorld setWorld;
 		setWorld.worldId = player.getVirtualWorld() + 1;
 		PacketHelper::send(setWorld, player);
 		setWorld.worldId--;
 		PacketHelper::send(setWorld, player);
+	}
+
+	void onPlayerClientInit(IPlayer& player) override
+	{
+		if (player.getClientVersion() != ClientVersion::ClientVersion_SAMP_03DL)
+			return;
+
+		if(DownloadAtConnect)
+			promptModelsForPlayer(player);
 	}
 
 	IEventDispatcher<PlayerModelsEventHandler>& getEventDispatcher() override
@@ -729,8 +735,10 @@ public:
 		{
 			return;
 		}
-
-		webServer->allowIPAddress(player.getNetworkData().networkID.address.v4);
+		if(DownloadAtConnect)
+		{
+			webServer->allowIPAddress(player.getNetworkData().networkID.address.v4);
+		}
 	}
 
 	void onPlayerDisconnect(IPlayer& player, PeerDisconnectReason reason) override
@@ -762,6 +770,22 @@ public:
 			return true;
 		}
 		return false;
+	}
+
+	bool setModelDownloadAtConnect(bool toggle) override
+	{
+		DownloadAtConnect = toggle;
+		return DownloadAtConnect;
+	}
+
+	bool startDownloadForPlayer(IPlayer& player) override
+	{
+		if(DownloadAtConnect)
+			return false;
+
+		webServer->allowIPAddress(player.getNetworkData().networkID.address.v4);
+		promptModelsForPlayer(player);
+		return true;
 	}
 };
 

--- a/Server/Components/Pawn/Scripting/CustomModels/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/CustomModels/Natives.cpp
@@ -132,6 +132,5 @@ SCRIPT_API(StartDownloadForPlayer, bool(IPlayer& player))
 	{
 		return false;
 	}
-		
 	return models->startDownloadForPlayer(player);
 }

--- a/Server/Components/Pawn/Scripting/CustomModels/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/CustomModels/Natives.cpp
@@ -113,3 +113,23 @@ SCRIPT_API(GetCustomModelPath, bool(int modelId, OutputOnlyString& dffPath, Outp
 
 	return status;
 }
+
+SCRIPT_API(SetModelDownloadAtConnect, bool(bool value))
+{
+	auto models = PawnManager::Get()->models;
+	
+	if(!models)
+		return false;
+
+	return models->setModelDownloadAtConnect(value);
+}
+
+SCRIPT_API(StartDownloadForPlayer, bool(IPlayer& player))
+{
+	auto models = PawnManager::Get()->models;
+	
+	if(!models)
+		return false;
+
+	return models->startDownloadForPlayer(player);
+}

--- a/Server/Components/Pawn/Scripting/CustomModels/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/CustomModels/Natives.cpp
@@ -118,7 +118,7 @@ SCRIPT_API(SetModelDownloadAtConnect, bool(bool value))
 {
 	auto models = PawnManager::Get()->models;
 	
-	if(!models)
+	if (!models)
 		return false;
 
 	return models->setModelDownloadAtConnect(value);
@@ -128,8 +128,10 @@ SCRIPT_API(StartDownloadForPlayer, bool(IPlayer& player))
 {
 	auto models = PawnManager::Get()->models;
 	
-	if(!models)
+	if (!models)
+	{
 		return false;
-
+	}
+		
 	return models->startDownloadForPlayer(player);
 }

--- a/Server/Components/Pawn/Scripting/Player/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Player/Natives.cpp
@@ -502,7 +502,12 @@ SCRIPT_API(RemoveBuildingForPlayer, bool(IPlayer& player, uint32_t model, Vector
 
 SCRIPT_API(GetPlayerBuildingsRemoved, int(IPlayer& player))
 {
-	return player.getDefaultObjectsRemoved();
+	return player.getDefaultObjectsRemovedCount();
+}
+
+SCRIPT_API(IsBuildingRemovedForPlayer, bool(IPlayer& player, uint32_t model, Vector3 pos, float radius))
+{
+	return player.isDefaultObjectRemoved(model, pos, radius);
 }
 
 SCRIPT_API(RemovePlayerFromVehicle, bool(IPlayer& player))

--- a/Server/Components/Pawn/Scripting/Vehicle/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/Vehicle/Natives.cpp
@@ -679,3 +679,20 @@ SCRIPT_API(CountVehicleOccupants, int(IVehicle& vehicle))
 	occupants += passengers.size();
 	return occupants;
 }
+
+SCRIPT_API(ShowVehicle, bool(IVehicle& vehicle))
+{
+	vehicle.toggleHide(false);
+	return true;
+}
+
+SCRIPT_API(HideVehicle, bool(IVehicle& vehicle))
+{
+	vehicle.toggleHide(true);
+	return true;
+}
+
+SCRIPT_API(IsVehicleHidden, bool(IVehicle& vehicle))
+{
+	return vehicle.isHidden();
+}

--- a/Server/Components/Vehicles/vehicle.hpp
+++ b/Server/Components/Vehicles/vehicle.hpp
@@ -67,6 +67,7 @@ private:
 	uint32_t hydraThrustAngle = 0;
 	float trainSpeed = 0.0f;
 	int lastDriverPoolID = INVALID_PLAYER_ID;
+	bool hidden_ = false;
 
 	/// Update the vehicle occupied status - set beenOccupied to true and update the lastOccupied time.
 	void updateOccupied()
@@ -153,6 +154,16 @@ public:
 
 	~Vehicle();
 	void destream();
+
+	void toggleHide(bool value) override
+	{
+		hidden_ = value;
+	}
+
+	bool isHidden() const override
+	{
+		return hidden_;
+	}
 
 	int getVirtualWorld() const override
 	{

--- a/Server/Components/Vehicles/vehicles_impl.hpp
+++ b/Server/Components/Vehicles/vehicles_impl.hpp
@@ -706,7 +706,7 @@ public:
 				}
 
 				const Vector2 dist2D = vehicle->getPosition() - player.getPosition();
-				const bool shouldBeStreamedIn = state != PlayerState_None && player.getVirtualWorld() == vehicle->getVirtualWorld() && (playerVehicle == vehicle || glm::dot(dist2D, dist2D) < maxDist);
+				const bool shouldBeStreamedIn = state != PlayerState_None && (vehicle->isHidden() != true) && player.getVirtualWorld() == vehicle->getVirtualWorld() && (playerVehicle == vehicle || glm::dot(dist2D, dist2D) < maxDist);
 
 				const bool isStreamedIn = vehicle->isStreamedInForPlayer(player);
 				if (!isStreamedIn && shouldBeStreamedIn)

--- a/Server/Source/player_impl.hpp
+++ b/Server/Source/player_impl.hpp
@@ -120,7 +120,6 @@ struct Player final : public IPlayer, public PoolIDProvider, public NoCopy
 	PlayerSpectateData spectateData_;
 	float gravity_;
 	bool ghostMode_;
-	//int defaultObjectsRemoved_;
 	DynamicArray<RemovedDefaultObject> defaultObjectsRemoved_;
 	bool allowWeapons_;
 	bool allowTeleport_;
@@ -960,7 +959,6 @@ public:
 		theObject.radius = radius;
 
 		defaultObjectsRemoved_.push_back(theObject);
-		//defaultObjectsRemoved_++;
 		NetCode::RPC::RemoveBuildingForPlayer removeBuildingForPlayerRPC;
 		removeBuildingForPlayerRPC.ModelID = model;
 		removeBuildingForPlayerRPC.Position = pos;
@@ -981,7 +979,7 @@ public:
 			{
 				float dist = (pos - object.pos).length();
 
-				if(dist + radius <= object.radius)
+				if (dist + radius <= object.radius)
 				{
 					return true;	
 				}

--- a/Server/Source/player_impl.hpp
+++ b/Server/Source/player_impl.hpp
@@ -959,7 +959,7 @@ public:
 		theObject.pos = pos;
 		theObject.radius = radius;
 
-		defaultObjectsRemoved_.push(theObject);
+		defaultObjectsRemoved_.push_back(theObject);
 		//defaultObjectsRemoved_++;
 		NetCode::RPC::RemoveBuildingForPlayer removeBuildingForPlayerRPC;
 		removeBuildingForPlayerRPC.ModelID = model;

--- a/Server/Source/player_impl.hpp
+++ b/Server/Source/player_impl.hpp
@@ -977,10 +977,15 @@ public:
 	{
 		for (const auto& object : defaultObjectsRemoved_)
 		{
-			if (model != object.ModelId) continue;
-			if (pos != object.pos) continue;
-			if (radius != object.radius) continue;
-			return true;
+			if (model == -1 || object.ModelId == -1 || model == object.ModelId)
+			{
+				float dist = (pos - object.pos).length();
+
+				if(dist + radius <= object.radius)
+				{
+					return true;	
+				}
+			}
 		}
 		return false;
 	}


### PR DESCRIPTION
## Inspired by both #1107 and #636.
#### Implements 2 new natives that, as it names portray, manages custom model downloading for players.

- `SetDownloadAtConnect(bool:toggle)` function takes a bool value and toggles whether player downloads custom models immediately after connecting or not.

- `StartDownloadForPlayer(playerid)` takes a single argument being the id of the player, and forces such player to begin custom models downloading.


#### Partially covers #636 by adding 3 new natives:

- `ShowVehicle(vehicleid)`
- `HideVehicle(vehicleid)`
- `IsVehicleHidden(vehicleid)`

Used to show, hide and check if a vehicle is on hidden state.

#### Changes to how server tracks removed objects for each player
By having now an actual list of removed buildings that you can query using a new native, `IsBuildingRemovedForPlayer`, while still being possible to fetch the count of deleted buildings.
