### PR TITLE
Fix Linux server deadlock on shutdown without TTY

### DIFF
--- a/Server/Components/Console/console_impl.hpp
+++ b/Server/Components/Console/console_impl.hpp
@@ -56,6 +56,7 @@ private:
 	{
 		std::atomic_bool valid;
 		ConsoleComponent* component;
+		std::atomic_bool isRunning;
 	};
 
 	ICore* core = nullptr;
@@ -211,7 +212,7 @@ public:
 
 		NetCode::Packet::PlayerRconCommand::addEventHandler(*core, &playerRconCommandHandler);
 
-		threadData = new ThreadProcData { true, this };
+		threadData = new ThreadProcData { true, this, true };
 		cinThread = std::thread(ThreadProc, threadData);
 		nativeThreadHandle = cinThread.native_handle();
 		cinThread.detach();
@@ -249,6 +250,7 @@ public:
 			}
 			else
 			{
+				threadData->isRunning = false;
 				return;
 			}
 		}
@@ -266,7 +268,10 @@ public:
 				cinThread.join();
 			}
 #else
-			pthread_cancel(nativeThreadHandle);
+			if (threadData->isRunning)
+			{
+				pthread_cancel(nativeThreadHandle);
+			}
 #endif
 
 			delete threadData;

--- a/Server/Components/Pawn/Plugin/Plugin.cpp
+++ b/Server/Components/Pawn/Plugin/Plugin.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "Plugin.h"
+#include <cstdarg>
 #include "../Manager/Manager.hpp"
 
 #ifdef WIN32


### PR DESCRIPTION
Fixes #1201

This PR fixes the issue where the Linux server hangs during shutdown if started without a TTY (e.g. through nohup). 

 
When running in background std::getline(std::wcin, line) fails because stdin is redirected/closed. The console thread exits gracefully early on. However, during shutdown, ~ConsoleComponent() blindly calls pthread_cancel() on the native thread handle, causing a deadlock or segfault because the thread is already dead.

My solution:
- Added an isRunning flag to ThreadProcData.
- Set it to false when the thread exits the read loop.
- Guarded the pthread_cancel call in the destructor to only execute if isRunning is true.

I've also:
- Added #include <cstdarg> to Server/Components/Pawn/Plugin/Plugin.cpp to fix some compilation errors on newer compilers like Clang 19 (I compiled my test build on Debian 13, but I'm not sure if that's intentional so feel free not to apply that). But it was likely missing because of stricter transitive includes in newer standard libraries

My testing process:
- Built on Debian 13 with Clang 19.
- Started server via nohup ./omp-server &.
- Sent kill -15 pid. Process shuts down cleanly instead of hanging indefinitely.