### PR TITLE
vehicle paintjob reset on respawn, SeedCookie timing, and NPC vehicle death events

### DIFF
--- a/Server/Components/LegacyNetwork/legacy_network_impl.cpp
+++ b/Server/Components/LegacyNetwork/legacy_network_impl.cpp
@@ -828,8 +828,6 @@ void RakNetLegacyNetwork::start()
 {
 	SAMPRakNet::Init(core);
 	SAMPRakNet::SeedToken();
-	lastCookieSeed = Time::now();
-	SAMPRakNet::SeedCookie();
 
 	playerFromRakIndex.fill(nullptr);
 
@@ -915,6 +913,14 @@ void RakNetLegacyNetwork::start()
 	{
 		rakNetServer.ReserveSlots(npcComponent->count());
 	}
+
+	// SeedCookie must be called after rakNetServer.Start() because Start() internally calls
+	// RakPeer::Disconnect() which resets RakNet's internal state. Seeding the cookie before
+	// Start() means the seeded value is discarded, leaving the cookie in an invalid state
+	// until the next onTick() re-seed. Clients connecting in that window fail the cookie
+	// check and their packets are silently ignored (issue #1211).
+	lastCookieSeed = Time::now();
+	SAMPRakNet::SeedCookie();
 }
 
 void RakNetLegacyNetwork::onTick(Microseconds elapsed, TimePoint now)

--- a/Server/Components/Vehicles/vehicle.cpp
+++ b/Server/Components/Vehicles/vehicle.cpp
@@ -707,6 +707,7 @@ void Vehicle::_respawn()
 	lastOccupiedChange = TimePoint();
 	timeOfSpawn = Time::now();
 	mods.fill(0);
+	// paintJob was not reset here unlike mods and colours, causing it to persist after vehicle respawn (issue #1212)
 	paintJob = 0;
 	doorDamage = 0;
 	tyreDamage = 0;

--- a/Server/Components/Vehicles/vehicle.cpp
+++ b/Server/Components/Vehicles/vehicle.cpp
@@ -707,6 +707,7 @@ void Vehicle::_respawn()
 	lastOccupiedChange = TimePoint();
 	timeOfSpawn = Time::now();
 	mods.fill(0);
+	paintJob = 0;
 	doorDamage = 0;
 	tyreDamage = 0;
 	lightDamage = 0;

--- a/Server/Components/Vehicles/vehicles_impl.hpp
+++ b/Server/Components/Vehicles/vehicles_impl.hpp
@@ -590,7 +590,12 @@ public:
 			Vehicle* vehicle = static_cast<Vehicle*>(v);
 			const Seconds delay = vehicle->getRespawnDelay();
 
-			if (!vehicle->isOccupied())
+			// A dead vehicle driven solely by an NPC has no client to send exit/death RPCs,
+			// so it stays "occupied" indefinitely. Treat it as unoccupied for death/respawn handling.
+			IPlayer* vehicleDriver = vehicle->getDriver();
+			bool deadNPCOnly = vehicle->isDead() && vehicleDriver != nullptr && vehicleDriver->isBot() && vehicle->getPassengers().empty();
+
+			if (!vehicle->isOccupied() || deadNPCOnly)
 			{
 				TimePoint lastOccupied = vehicle->getLastOccupiedTime();
 				if (vehicle->isDead())


### PR DESCRIPTION
### 1. Reset paintjob on vehicle respawn (closes #1212)

Vehicle paintjob was not being cleared in `_respawn()` alongside other visual properties (mods, colours). After respawn the paintjob persisted, causing a desync between the vehicle's visual state and its server-side data.

**Fix:** Added `paintJob = 0` to `Vehicle::_respawn()` in `vehicle.cpp`.

---

### 2. Move SeedCookie after rakNetServer.Start() (closes #1211)

`SeedCookie` was being set before the RakNet server started, which could cause connection failures in certain scenarios.

**Fix:** Moved `SeedCookie` call to after `rakNetServer.Start()`.

---

### 3. Fix OnVehicleDeath / OnVehicleSpawn not firing for NPC-driven vehicles (closes #1196)

NPCs don’t send exit/death RPCs, so vehicles stay permanently occupied. This blocks the `onTick` respawn logic and prevents `OnVehicleDeath/Spawn`, leaving vehicles in a zombie state.

**Fix:** In `VehiclesComponent::onTick()` (`vehicles_impl.hpp`), detect the case where a dead vehicle's only occupant is an NPC driver and bypass the occupation check. The existing `_respawn()` already clears the driver pointer, so no further changes are needed.