### PR TITLE
Fix camera target player-object via dedicated extension

### DIFF
--- a/Server/Components/CAPI/Impl/Objects/APIs.cpp
+++ b/Server/Components/CAPI/Impl/Objects/APIs.cpp
@@ -821,10 +821,10 @@ OMP_CAPI(Player_GetSurfingPlayerObject, objectPtr(objectPtr player))
 OMP_CAPI(Player_GetCameraTargetPlayerObject, objectPtr(objectPtr player))
 {
 	POOL_ENTITY_RET(players, IPlayer, player, player_, nullptr);
-	IObject* object = player_->getCameraTargetObject();
-	if (object)
+	IPlayerCameraTargetData* data = queryExtension<IPlayerCameraTargetData>(player_);
+	if (!data)
 	{
-		return object;
+		return nullptr;
 	}
-	return nullptr;
+	return data->getCameraTargetPlayerObject();
 }

--- a/Server/Components/Pawn/Scripting/Object/PlayerNatives.cpp
+++ b/Server/Components/Pawn/Scripting/Object/PlayerNatives.cpp
@@ -287,7 +287,12 @@ SCRIPT_API(GetPlayerSurfingPlayerObjectID, int(IPlayer& player))
 
 SCRIPT_API(GetPlayerCameraTargetPlayerObj, int(IPlayer& player))
 {
-	IObject* object = player.getCameraTargetObject();
+	IPlayerCameraTargetData* data = queryExtension<IPlayerCameraTargetData>(player);
+	if (!data)
+	{
+		return INVALID_OBJECT_ID;
+	}
+	IPlayerObject* object = data->getCameraTargetPlayerObject();
 	if (object)
 	{
 		return object->getID();

--- a/Server/Source/player.cpp
+++ b/Server/Source/player.cpp
@@ -123,23 +123,23 @@ IObject* Player::getCameraTargetObject()
 		return nullptr;
 	}
 
-	IObject* object = component->get(cameraTargetObject_);
+	return component->get(cameraTargetObject_);
+}
 
-	if (!object)
+IPlayerObject* PlayerCameraTargetData::getCameraTargetPlayerObject()
+{
+	if (!player_.enableCameraTargeting_)
 	{
-		IPlayerObjectData* data = queryExtension<IPlayerObjectData>(this);
-
-		if (data)
-		{
-			IPlayerObject* player_object = data->get(cameraTargetObject_);
-			if (player_object)
-			{
-				return reinterpret_cast<IObject*>(player_object);
-			}
-		}
+		return nullptr;
 	}
 
-	return object;
+	IPlayerObjectData* data = queryExtension<IPlayerObjectData>(&player_);
+	if (!data)
+	{
+		return nullptr;
+	}
+
+	return data->get(player_.cameraTargetObject_);
 }
 
 IPlayer* Player::getTargetPlayer()

--- a/Server/Source/player_impl.hpp
+++ b/Server/Source/player_impl.hpp
@@ -53,6 +53,31 @@ enum SecondarySyncUpdateType
 	SecondarySyncUpdateType_Trailer = (1 << 2),
 };
 
+struct Player;
+
+class PlayerCameraTargetData final : public IPlayerCameraTargetData
+{
+private:
+	Player& player_;
+
+public:
+	PlayerCameraTargetData(Player& player)
+		: player_(player)
+	{
+	}
+
+	IPlayerObject* getCameraTargetPlayerObject() override;
+
+	void freeExtension() override
+	{
+		delete this;
+	}
+
+	void reset() override
+	{
+	}
+};
+
 struct Player final : public IPlayer, public PoolIDProvider, public NoCopy
 {
 	PlayerPool& pool_;
@@ -275,6 +300,7 @@ struct Player final : public IPlayer, public PoolIDProvider, public NoCopy
 	{
 		weapons_.fill({ 0, 0 });
 		skillLevels_.fill(MAX_SKILL_LEVEL);
+		addExtension(new PlayerCameraTargetData(*this), true);
 	}
 
 	void ban(StringView reason) override;


### PR DESCRIPTION
Closes #1070
Depends on openmultiplayer/open.mp-sdk#68

Implemented as an `IExtension` rather than a new virtual on `IPlayer` so
the `IPlayer` and `IPlayerObjectData` vtables stay byte-for-byte
unchanged and pre-built components remain binary-compatible