### PR TITLE
Forward unknown UIDs to IExtensible::getExtension in RakNetLegacyNetwork

### DIFF
--- a/Server/Components/LegacyNetwork/legacy_network_impl.hpp
+++ b/Server/Components/LegacyNetwork/legacy_network_impl.hpp
@@ -82,7 +82,7 @@ public:
 		{
 			return static_cast<INetworkQueryExtension*>(this);
 		}
-		return nullptr;
+		return IExtensible::getExtension(id);
 	}
 
 	ENetworkType getNetworkType() const override


### PR DESCRIPTION
RakNetLegacyNetwork::getExtension returned nullptr for any UID other
than INetworkQueryExtension, which silently dropped extensions added via
`addExtension(...)`

Relates to openmultiplayer/open.mp-sdk#69