### PR TITLE
CAPI: Fix legacy slots not being released for GZ and Pickups

### DIFF
--- a/Server/Components/CAPI/Impl/GangZones/APIs.cpp
+++ b/Server/Components/CAPI/Impl/GangZones/APIs.cpp
@@ -46,8 +46,9 @@ OMP_CAPI(GangZone_Create, objectPtr(float minx, float miny, float maxx, float ma
 OMP_CAPI(GangZone_Destroy, bool(objectPtr gangzone))
 {
 	POOL_ENTITY_RET(gangzones, IGangZone, gangzone, gz, false);
+	int legacyID = gangzones->toLegacyID(gz->getID());
 	gangzones->release(gz->getID());
-	gangzones->releaseLegacyID(gangzones->toLegacyID(gz->getID()));
+	gangzones->releaseLegacyID(legacyID);
 	return true;
 }
 

--- a/Server/Components/CAPI/Impl/Pickups/APIs.cpp
+++ b/Server/Components/CAPI/Impl/Pickups/APIs.cpp
@@ -62,8 +62,9 @@ OMP_CAPI(Pickup_AddStatic, bool(int model, int type, float x, float y, float z, 
 OMP_CAPI(Pickup_Destroy, bool(objectPtr pickup))
 {
 	POOL_ENTITY_RET(pickups, IPickup, pickup, p, false);
+	int legacyID = pickups->toLegacyID(p->getID());
 	pickups->release(p->getID());
-	pickups->releaseLegacyID(pickups->toLegacyID(p->getID()));
+	pickups->releaseLegacyID(legacyID);
 	return true;
 }
 


### PR DESCRIPTION
Fixes https://github.com/openmultiplayer/open.mp/issues/1199

Currently attempts to release legacy id after real id is released, which destroys the gz and causes the legacy id to be -1. This patch first stores the legacy id to avoid this, which is how it seems to already be done for pawn (Gangzones/Natives.cpp line 44 to 58)

Disclaimer: I've been unable to test this because I cannot make conan and PyYAML play ball with my windows python env. I'll try again when I have time, but this seems straightforwards enough.