### PR TITLE
Some more fixes for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ cmake --build . --config RelWithDebInfo
 
 ## Building on Mac
 
-If you install conan via brew you must ensure you get the correct version; however, the cmake-conan script will not detect it from the default install location.  You must therefore also alias it elsewhere:
+If you install conan via brew the cmake-conan script will not detect it from the default install location.  You must therefore also alias it elsewhere:
 
 ```bash
-brew install conan@1
-sudo ln -s /usr/local/opt/conan@1/bin/conan /usr/local/bin/conan
+brew install conan
+sudo ln -s /usr/local/opt/conan/bin/conan /usr/local/bin/conan
 cd open.mp
 mkdir build
 cd build

--- a/Server/Source/util.hpp
+++ b/Server/Source/util.hpp
@@ -31,6 +31,9 @@ static LARGE_INTEGER yo;
 #include <stdlib.h>
 #include <sys/time.h>
 #include <unistd.h>
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
 #define SET_TICKER_RESOLUTION(ms)
 #define LIBRARY_OPEN(path) dlopen(path, RTLD_LAZY | RTLD_LOCAL)
 #define LIBRARY_OPEN_GLOBAL(path) dlopen(path, RTLD_LAZY | RTLD_GLOBAL)
@@ -148,6 +151,19 @@ ghc::filesystem::path GetExecutablePath()
 	if (GetModuleFileNameA(nullptr, path, sizeof(path)))
 	{
 		return ghc::filesystem::canonical(path);
+	}
+	else
+	{
+		return ghc::filesystem::path();
+	}
+#elif defined(__APPLE__)
+	char path[4096] = { 0 };
+	uint32_t size = sizeof(path);
+	if (_NSGetExecutablePath(path, &size) == 0)
+	{
+		std::error_code ec;
+		auto canonicalPath = ghc::filesystem::canonical(path, ec);
+		return ec ? ghc::filesystem::path(path) : canonicalPath;
 	}
 	else
 	{


### PR DESCRIPTION
Related to #1234

**UPD:** Playing with compiled omp macOS server I just found a stale and latent bug which I couldn't catch any before ([click to see how it looked like](https://imgur.com/a/2fqF7n1)), and it happened only when no any components were loaded. After some analysis I found out that it wasn't a regression from any recent commits and has been always a broken thing, it just didn't happen on usual use cases. Since the initial PR targeted to macOS fixes, I also include the `/proc/self/exe` path fix here. It was **tested** and the mentioned issue from screenshot is now gone with these changes in 2fcd410.