### PR TITLE
fix: NPC_PutInVehicle not visually attaching NPC to boat seat

### DIFF
--- a/Server/Components/NPCs/NPC/npc.cpp
+++ b/Server/Components/NPCs/NPC/npc.cpp
@@ -1539,6 +1539,18 @@ bool NPC::putInVehicle(IVehicle& vehicle, uint8_t seat)
 	vehicle_ = &vehicle;
 	vehicleSeat_ = seat;
 
+	// Vehicle::putPlayer only sends PutPlayerInVehicle to the entering player,
+	// which is a no-op for an NPC (no real client to receive it). Without an
+	// explicit broadcast, remote clients have no signal to visually attach the
+	// NPC and must rely on the next DriverSync, which some vehicles (notably
+	// boats) refuse to honour while the player is on-foot. Mirror the natural
+	// goToVehicle flow by broadcasting EnterVehicle to streamed players.
+	NetCode::RPC::EnterVehicle enterVehicleRPC;
+	enterVehicleRPC.PlayerID = player_->getID();
+	enterVehicleRPC.VehicleID = vehicle.getID();
+	enterVehicleRPC.Passenger = (seat != 0) ? 1 : 0;
+	PacketHelper::broadcastToStreamed(enterVehicleRPC, *player_, true);
+
 	auto angle = vehicle.getRotation().ToEuler().z;
 	auto rotation = getRotation().ToEuler();
 	rotation.z = angle;


### PR DESCRIPTION
## Summary

Fixes #1225 — `NPC_PutInVehicle` updates logical state correctly (`NPC_GetVehicle`/`NPC_GetVehicleSeat` return expected values) but the NPC remains visually on foot for boats (tested with models 595 Launch, 446 Squalo).

## Root cause

`NPC::putInVehicle` calls `Vehicle::putPlayer`, which sends the `PutPlayerInVehicle` RPC **only to the entering player**. For an NPC this is a no-op — it has no real client to receive the RPC. Other streamed-in clients receive no broadcast and must rely on the next periodic `DriverSync` to visually attach the NPC. While the SA-MP client auto-attaches a remote player to most vehicles from `DriverSync` alone, boats refuse to honour this when the local view still shows the player on foot, so the NPC stays visually on foot even though every server-side data structure agrees the NPC is the driver.

The natural `goToVehicle` flow does not have this problem because it emulates `OnPlayerEnterVehicle` first, whose handler broadcasts `EnterVehicle` to streamed players. That broadcast is the signal the SA-MP client needs to actually attach the NPC.

## Fix

In `Server/Components/NPCs/NPC/npc.cpp`, inside `NPC::putInVehicle`, broadcast `NetCode::RPC::EnterVehicle` to streamed-in players immediately after `Vehicle::putPlayer` and the `vehicle_` / `vehicleSeat_` assignment. This mirrors the natural entry path without firing the `OnPlayerEnterVehicle` pawn callback.

```cpp
NetCode::RPC::EnterVehicle enterVehicleRPC;
enterVehicleRPC.PlayerID = player_->getID();
enterVehicleRPC.VehicleID = vehicle.getID();
enterVehicleRPC.Passenger = (seat != 0) ? 1 : 0;
PacketHelper::broadcastToStreamed(enterVehicleRPC, *player_, true);
```

## Test plan

- [ ] Spawn an NPC near a boat (model 595 Launch).
- [ ] Call `NPC_PutInVehicle(npc, boatId, 0)` from a command while a real player stands near the boat.
- [ ] Confirm the NPC visually attaches to the boat seat instead of staying on foot.
- [ ] Repeat for model 446 Squalo.
- [ ] Regression check: cars (any seated land vehicle) still work and the natural `NPC_GoToVehicle` flow is unaffected.
- [ ] Verify `NPC_GetVehicle` / `NPC_GetVehicleSeat` still return correct values.

## Notes

- No SDK / ABI surface changes — fix is entirely inside the NPC component.
- `PacketHelper` and `NetCode::RPC::EnterVehicle` are already transitively included via `netcode.hpp`.
- Closes #1225.