### PR TITLE
Add NPC_GetVehiclePos and NPC_GetVehicleRot natives

### DIFF
--- a/Server/Components/NPCs/NPC/npc.cpp
+++ b/Server/Components/NPCs/NPC/npc.cpp
@@ -280,6 +280,24 @@ void NPC::setVehicleRotation(const GTAQuat& rotation, bool immediateUpdate)
 	}
 }
 
+Vector3 NPC::getVehiclePosition() const
+{
+	if (vehicle_ && vehicleSeat_ != SEAT_NONE)
+	{
+		return position_;
+	}
+	return Vector3(0.0f, 0.0f, 0.0f);
+}
+
+GTAQuat NPC::getVehicleRotation() const
+{
+	if (vehicle_ && vehicleSeat_ != SEAT_NONE)
+	{
+		return rotation_;
+	}
+	return GTAQuat();
+}
+
 int NPC::getVirtualWorld() const
 {
 	return player_->getVirtualWorld();

--- a/Server/Components/NPCs/NPC/npc.hpp
+++ b/Server/Components/NPCs/NPC/npc.hpp
@@ -262,6 +262,10 @@ public:
 
 	void setVehicleRotation(const GTAQuat& rotation, bool immediateUpdate) override;
 
+	Vector3 getVehiclePosition() const override;
+
+	GTAQuat getVehicleRotation() const override;
+
 	void setPositionHandled(const Vector3& position, bool immediateUpdate)
 	{
 		if (vehicle_ && vehicleSeat_ != SEAT_NONE)

--- a/Server/Components/Pawn/Scripting/NPC/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/NPC/Natives.cpp
@@ -80,6 +80,12 @@ SCRIPT_API(NPC_SetVehiclePos, bool(INPC& npc, Vector3 position))
 	return true;
 }
 
+SCRIPT_API(NPC_GetVehiclePos, bool(INPC& npc, Vector3& position))
+{
+	position = npc.getVehiclePosition();
+	return true;
+}
+
 SCRIPT_API(NPC_GetPos, bool(INPC& npc, Vector3& position))
 {
 	position = npc.getPosition();
@@ -95,6 +101,12 @@ SCRIPT_API(NPC_SetRot, bool(INPC& npc, Vector3 rotation))
 SCRIPT_API(NPC_SetVehicleRot, bool(INPC& npc, Vector3 rotation))
 {
 	npc.setVehicleRotation(rotation, true);
+	return true;
+}
+
+SCRIPT_API(NPC_GetVehicleRot, bool(INPC& npc, Vector3& rotation))
+{
+	rotation = npc.getVehicleRotation().ToEuler();
 	return true;
 }
 


### PR DESCRIPTION
Closes #1197.

## Summary

Adds the getter counterparts to `NPC_SetVehiclePos` / `NPC_SetVehicleRot`, as requested in #1197.

- `INPC::getVehiclePosition()` and `INPC::getVehicleRotation()` — SDK side (see paired SDK PR openmultiplayer/open.mp-sdk#71)
- `NPC::getVehiclePosition()` / `NPC::getVehicleRotation()` — implementations in `Server/Components/NPCs/NPC/npc.cpp`
- `NPC_GetVehiclePos(npcid, &Float:x, &Float:y, &Float:z)` and `NPC_GetVehicleRot(npcid, &Float:x, &Float:y, &Float:z)` — PAWN natives in `Server/Components/Pawn/Scripting/NPC/Natives.cpp`

Both getters return zero/identity when the NPC is not currently in a vehicle, matching the silent no-op semantics of the existing setters.

## Depends on

- openmultiplayer/open.mp-sdk#71 — must merge first. Submodule pointer in this PR points to the head of that branch (`324eb80`); it will need to be re-pointed to the merged SHA once the SDK PR lands.

A companion PR to [openmultiplayer/omp-stdlib](https://github.com/openmultiplayer/omp-stdlib) for the `.inc` declarations of `NPC_GetVehiclePos` / `NPC_GetVehicleRot` is still to be opened.

## Test plan

- [ ] CI build green (Linux/Windows/macOS) once SDK PR merged and submodule re-pointed
- [ ] In-game: spawn NPC, put in vehicle, confirm `NPC_GetVehiclePos` and `NPC_GetVehicleRot` return values matching what was written via the corresponding setters
- [ ] Out of vehicle: confirm both natives return zeroed `Vector3`