### PR TITLE
Fix moving NPC vehicle pitch not synced

### DIFF
--- a/Server/Components/NPCs/NPC/npc.cpp
+++ b/Server/Components/NPCs/NPC/npc.cpp
@@ -2222,15 +2222,10 @@ void NPC::sendDriverSync()
 	{
 		return;
 	}
-
 	uint16_t upAndDown, leftAndRight, keys;
 	getKeys(upAndDown, leftAndRight, keys);
-
 	uint16_t vehicleID = vehicle_->getID();
-
-	// Check if immediate update is needed (basic comparison for now)
 	bool needsImmediateUpdate = driverSync_.LeftRight != leftAndRight || driverSync_.UpDown != upAndDown || driverSync_.Keys != keys || driverSync_.Position != position_ || driverSync_.Rotation.q != rotation_.q || driverSync_.PlayerHealthArmour.x != health_ || driverSync_.PlayerHealthArmour.y != armour_ || driverSync_.VehicleID != vehicleID || driverSync_.Velocity != velocity_ || driverSync_.Health != vehicleHealth_;
-
 	auto generateDriverSyncBitStream = [&](NetworkBitStream& bs)
 	{
 		driverSync_.VehicleID = vehicleID;
@@ -2243,16 +2238,14 @@ void NPC::sendDriverSync()
 		driverSync_.PlayerHealthArmour.y = armour_;
 		driverSync_.Velocity = velocity_;
 		driverSync_.Health = vehicleHealth_;
-
 		driverSync_.Siren = uint8_t(useVehicleSiren_);
 		driverSync_.LandingGear = vehicleGearState_;
-
 		int model = vehicle_->getModel();
-		if (model == 520) // hydra model id
+		if (model == 520)
 		{
 			driverSync_.HydraThrustAngle = hydraThrusterDirection_;
 		}
-		else if (model == 537 || model == 538 || model == 570 || model == 569 || model == 449) // train part models
+		else if (model == 537 || model == 538 || model == 570 || model == 569 || model == 449)
 		{
 			driverSync_.TrainSpeed = vehicleTrainSpeed_;
 		}
@@ -2260,17 +2253,37 @@ void NPC::sendDriverSync()
 		{
 			driverSync_.TrainSpeed = 0.0f;
 		}
-
 		driverSync_.TrailerID = INVALID_VEHICLE_ID;
 		driverSync_.HasTrailer = false;
 		driverSync_.AdditionalKeyWeapon = weapon_;
-
 		bs.writeUINT8(driverSync_.PacketID);
 		bs.writeUINT16(driverSync_.VehicleID);
 		bs.writeUINT16(driverSync_.LeftRight);
 		bs.writeUINT16(driverSync_.UpDown);
 		bs.writeUINT16(driverSync_.Keys);
-		bs.writeVEC4(Vector4(driverSync_.Rotation.q.w, driverSync_.Rotation.q.x, driverSync_.Rotation.q.y, driverSync_.Rotation.q.z));
+
+		// Pitch-adjusted rotation
+		GTAQuat syncRotation = rotation_;
+		if (moving_)
+		{
+			float dx = targetPosition_.x - position_.x;
+			float dy = targetPosition_.y - position_.y;
+			float dz = targetPosition_.z - position_.z;
+			float pitch = -atan2(dz, sqrt(dx * dx + dy * dy));
+
+			float qw = rotation_.q.w, qx = rotation_.q.x, qy = rotation_.q.y, qz = rotation_.q.z;
+			float yaw = atan2(2.0f * (qw * qz + qx * qy), 1.0f - 2.0f * (qy * qy + qz * qz));
+
+			float cy = cos(yaw * 0.5f), sy = sin(yaw * 0.5f);
+			float cp = cos(pitch * 0.5f), sp = sin(pitch * 0.5f);
+
+			syncRotation.q.w = cy * cp;
+			syncRotation.q.x = cy * sp;
+			syncRotation.q.y = -sy * sp;
+			syncRotation.q.z = sy * cp;
+		}
+		bs.writeVEC4(Vector4(syncRotation.q.w, syncRotation.q.x, syncRotation.q.y, syncRotation.q.z));
+
 		bs.writeVEC3(driverSync_.Position);
 		bs.writeVEC3(driverSync_.Velocity);
 		bs.writeFLOAT(driverSync_.Health);
@@ -2282,7 +2295,6 @@ void NPC::sendDriverSync()
 		bs.writeUINT16(driverSync_.TrailerID);
 		bs.writeUINT32(driverSync_.HydraThrustAngle);
 	};
-
 	if (needsImmediateUpdate)
 	{
 		NetworkBitStream bs;

--- a/Server/Components/NPCs/NPC/npc.cpp
+++ b/Server/Components/NPCs/NPC/npc.cpp
@@ -499,8 +499,17 @@ bool NPC::move(Vector3 pos, NPCMoveType moveType, float moveSpeed, float stopRan
 	{
 		front = (pos - position) / distance;
 		auto rotation = getRotation().ToEuler();
+		rotation.x = 0.0f; // Discard the pitch a previous drive move may have baked in, it would skew the facing angle
 		rotation.z = getAngleOfLine(front.x, front.y);
 		rotation_ = GTAQuat(rotation); // Do this directly, if you use NPC::setRotation it's going to cause recursion
+
+		if (moveType_ == NPCMoveType_Drive)
+		{
+			// Tilt the vehicle to match the slope towards the target
+			const float pitch = -atan2(front.z, glm::length(glm::vec2(front)));
+			const float yaw = glm::roll(rotation_.q); // glm is Y up, so its roll() is the rotation around our Z axis
+			rotation_.q = glm::angleAxis(pitch, Vector3(1.0f, 0.0f, 0.0f)) * glm::angleAxis(yaw, Vector3(0.0f, 0.0f, 1.0f));
+		}
 
 		// Calculate velocity to use on tick
 		velocity_ = front * (moveSpeed_ / 100.0f);
@@ -2270,29 +2279,7 @@ void NPC::sendDriverSync()
 		bs.writeUINT16(driverSync_.LeftRight);
 		bs.writeUINT16(driverSync_.UpDown);
 		bs.writeUINT16(driverSync_.Keys);
-
-		// Pitch-adjusted rotation
-		GTAQuat syncRotation = rotation_;
-		if (moving_)
-		{
-			float dx = targetPosition_.x - position_.x;
-			float dy = targetPosition_.y - position_.y;
-			float dz = targetPosition_.z - position_.z;
-			float pitch = -atan2(dz, sqrt(dx * dx + dy * dy));
-
-			float qw = rotation_.q.w, qx = rotation_.q.x, qy = rotation_.q.y, qz = rotation_.q.z;
-			float yaw = atan2(2.0f * (qw * qz + qx * qy), 1.0f - 2.0f * (qy * qy + qz * qz));
-
-			float cy = cos(yaw * 0.5f), sy = sin(yaw * 0.5f);
-			float cp = cos(pitch * 0.5f), sp = sin(pitch * 0.5f);
-
-			syncRotation.q.w = cy * cp;
-			syncRotation.q.x = cy * sp;
-			syncRotation.q.y = -sy * sp;
-			syncRotation.q.z = sy * cp;
-		}
-
-		bs.writeVEC4(Vector4(syncRotation.q.w, syncRotation.q.x, syncRotation.q.y, syncRotation.q.z));
+		bs.writeVEC4(Vector4(driverSync_.Rotation.q.w, driverSync_.Rotation.q.x, driverSync_.Rotation.q.y, driverSync_.Rotation.q.z));
 		bs.writeVEC3(driverSync_.Position);
 		bs.writeVEC3(driverSync_.Velocity);
 		bs.writeFLOAT(driverSync_.Health);

--- a/Server/Components/NPCs/NPC/npc.cpp
+++ b/Server/Components/NPCs/NPC/npc.cpp
@@ -499,16 +499,22 @@ bool NPC::move(Vector3 pos, NPCMoveType moveType, float moveSpeed, float stopRan
 	{
 		front = (pos - position) / distance;
 		auto rotation = getRotation().ToEuler();
-		rotation.x = 0.0f; // Discard the pitch a previous drive move may have baked in, it would skew the facing angle
 		rotation.z = getAngleOfLine(front.x, front.y);
-		rotation_ = GTAQuat(rotation); // Do this directly, if you use NPC::setRotation it's going to cause recursion
 
 		if (moveType_ == NPCMoveType_Drive)
 		{
+			rotation.x = 0.0f; // The slope pitch is recalculated below, drop whatever a previous move left here
+			rotation_ = GTAQuat(rotation); // Do this directly, if you use NPC::setRotation it's going to cause recursion
+
 			// Tilt the vehicle to match the slope towards the target
 			const float pitch = -atan2(front.z, glm::length(glm::vec2(front)));
 			const float yaw = glm::roll(rotation_.q); // glm is Y up, so its roll() is the rotation around our Z axis
 			rotation_.q = glm::angleAxis(pitch, Vector3(1.0f, 0.0f, 0.0f)) * glm::angleAxis(yaw, Vector3(0.0f, 0.0f, 1.0f));
+		}
+		else
+		{
+			rotation.x = 0.0f; // A previous drive move may have left a pitch here, it would make the ped lean
+			rotation_ = GTAQuat(rotation); // Do this directly, if you use NPC::setRotation it's going to cause recursion
 		}
 
 		// Calculate velocity to use on tick

--- a/Server/Components/NPCs/NPC/npc.cpp
+++ b/Server/Components/NPCs/NPC/npc.cpp
@@ -2222,10 +2222,15 @@ void NPC::sendDriverSync()
 	{
 		return;
 	}
+
 	uint16_t upAndDown, leftAndRight, keys;
 	getKeys(upAndDown, leftAndRight, keys);
+
 	uint16_t vehicleID = vehicle_->getID();
+
+	// Check if immediate update is needed (basic comparison for now)
 	bool needsImmediateUpdate = driverSync_.LeftRight != leftAndRight || driverSync_.UpDown != upAndDown || driverSync_.Keys != keys || driverSync_.Position != position_ || driverSync_.Rotation.q != rotation_.q || driverSync_.PlayerHealthArmour.x != health_ || driverSync_.PlayerHealthArmour.y != armour_ || driverSync_.VehicleID != vehicleID || driverSync_.Velocity != velocity_ || driverSync_.Health != vehicleHealth_;
+
 	auto generateDriverSyncBitStream = [&](NetworkBitStream& bs)
 	{
 		driverSync_.VehicleID = vehicleID;
@@ -2238,14 +2243,16 @@ void NPC::sendDriverSync()
 		driverSync_.PlayerHealthArmour.y = armour_;
 		driverSync_.Velocity = velocity_;
 		driverSync_.Health = vehicleHealth_;
+
 		driverSync_.Siren = uint8_t(useVehicleSiren_);
 		driverSync_.LandingGear = vehicleGearState_;
+
 		int model = vehicle_->getModel();
-		if (model == 520)
+		if (model == 520) // hydra model id
 		{
 			driverSync_.HydraThrustAngle = hydraThrusterDirection_;
 		}
-		else if (model == 537 || model == 538 || model == 570 || model == 569 || model == 449)
+		else if (model == 537 || model == 538 || model == 570 || model == 569 || model == 449) // train part models
 		{
 			driverSync_.TrainSpeed = vehicleTrainSpeed_;
 		}
@@ -2253,9 +2260,11 @@ void NPC::sendDriverSync()
 		{
 			driverSync_.TrainSpeed = 0.0f;
 		}
+
 		driverSync_.TrailerID = INVALID_VEHICLE_ID;
 		driverSync_.HasTrailer = false;
 		driverSync_.AdditionalKeyWeapon = weapon_;
+
 		bs.writeUINT8(driverSync_.PacketID);
 		bs.writeUINT16(driverSync_.VehicleID);
 		bs.writeUINT16(driverSync_.LeftRight);
@@ -2282,8 +2291,8 @@ void NPC::sendDriverSync()
 			syncRotation.q.y = -sy * sp;
 			syncRotation.q.z = sy * cp;
 		}
-		bs.writeVEC4(Vector4(syncRotation.q.w, syncRotation.q.x, syncRotation.q.y, syncRotation.q.z));
 
+		bs.writeVEC4(Vector4(syncRotation.q.w, syncRotation.q.x, syncRotation.q.y, syncRotation.q.z));
 		bs.writeVEC3(driverSync_.Position);
 		bs.writeVEC3(driverSync_.Velocity);
 		bs.writeFLOAT(driverSync_.Health);
@@ -2295,6 +2304,7 @@ void NPC::sendDriverSync()
 		bs.writeUINT16(driverSync_.TrailerID);
 		bs.writeUINT32(driverSync_.HydraThrustAngle);
 	};
+
 	if (needsImmediateUpdate)
 	{
 		NetworkBitStream bs;


### PR DESCRIPTION
rotation sent in driver sync previously only used yaw, so moving npc vehicles looked flat instead of tilting toward their direction of travel. 
now pitch is calculated from position vs target position while moving_, then combined with yaw before sync.