### PR TITLE
Fix NPC_SetAngleToPos(): use {vec.x, vec.y} instead of {vec.x, vec.z}

### DIFF
--- a/Server/Components/Pawn/Scripting/NPC/Natives.cpp
+++ b/Server/Components/Pawn/Scripting/NPC/Natives.cpp
@@ -1141,7 +1141,7 @@ SCRIPT_API(NPC_GetPosMovingTo, bool(INPC& npc, Vector3& position))
 SCRIPT_API(NPC_SetAngleToPos, bool(INPC& npc, Vector3 position))
 {
 	auto vec = position - npc.getPosition();
-	auto angle = getAngleOfLine(vec.x, vec.z);
+	auto angle = getAngleOfLine(vec.x, vec.y);
 	openmp_scripting::NPC_SetFacingAngle(npc, angle);
 	return true;
 }


### PR DESCRIPTION
Use `vec.x, vec.y` in `getAngleOfLine` in `NPC_SetAngleToPos()` instead of `vec.x, vec.z`
Fixes #1251 